### PR TITLE
Refine tooltip layout and styles

### DIFF
--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -30,7 +30,7 @@ export default Ember.Component.extend({
 
     onClick() {},
 
-    tooltipDateFormat: 'L LT',
+    tooltipDateFormat: 'll LT',
 
     type: 'GROUPED', // GROUPED, LAYERED (overlapping, first series in back -- should only be used for proportions), TODO: add STACKED
 
@@ -77,10 +77,10 @@ export default Ember.Component.extend({
 
         let tip = d3.tip().attr('class', 'd3-tip').html(function (d) {
             if (!_.isEmpty(titles)) {
-                let str = `<span class="tooltip-time">${moment(d.data.key).format(tooltipDateFormat)}</span><br/>`;
+                let str = `<span class="tooltip-time">${moment(d.data.key).format(tooltipDateFormat)}</span>`;
                 _.forEach(titles, function (title, i) {
                     const datum = formatter(data[d.data.key][i]);
-                    str = str.concat(`<span class="tooltip-value">${title}: ${datum}</span><br/>`);
+                    str = str.concat(`<span class="tooltip-list-item"><span class="tooltip-label">${title}</span><span class="tooltip-value">${datum}</span></span>`);
                 });
                 return str;
             }

--- a/addon/components/column-chart/style.less
+++ b/addon/components/column-chart/style.less
@@ -1,3 +1,2 @@
 .column-chart {
-    font-family: "Lato", Helvetica Neue", Helvetica, Arial, sans-serif;
 }

--- a/addon/styles/addon.less
+++ b/addon/styles/addon.less
@@ -1,1 +1,4 @@
+@import 'variables';
+
 @import 'chart';
+@import 'components/column-chart/style.less';

--- a/addon/styles/chart.less
+++ b/addon/styles/chart.less
@@ -1,6 +1,9 @@
+@import url('https://fonts.googleapis.com/css?family=Lato:300,400,700');
+
 .chart {
     display: flex;
     flex-direction: column;
+    font-family: @font-family;
     height: 100%;
     width: 100%;
 
@@ -28,6 +31,12 @@
         font-weight: bold;
     }
 
+    .axis {
+        text {
+            fill: @silver-chalice;
+        }
+    }
+
     .x.axis {
         margin-bottom: 5px;
         overflow: visible;
@@ -37,7 +46,7 @@
     .x.axis line,
     .x.axis path {
         fill: none;
-        stroke: #d1d1d1;
+        stroke: @alto;
         stroke-width: 1px;
         shape-rendering: crispEdges;
     }
@@ -58,21 +67,21 @@
     .yr.axis line,
     .yr.axis path {
         fill: none;
-        stroke: #d1d1d1;
+        stroke: @alto;
         stroke-width: 1px;
         shape-rendering: crispEdges;
     }
 
     .grid-line {
         fill: none;
-        stroke: #ccc;
+        stroke: @silver;
         opacity: .5;
         shape-rendering: crispEdges;
     }
 
     .grid-line line {
         fill: none;
-        stroke: #ccc;
+        stroke: @silver;
         opacity: .5;
         shape-rendering: crispEdges;
     }
@@ -87,8 +96,8 @@
     }
 
     .brush .resize path {
-        fill: #eee;
-        stroke: #666;
+        fill: @gallery;
+        stroke: @dove-gray;
     }
 
     .legend text,
@@ -99,18 +108,53 @@
 }
 
 .d3-tip {
-          line-height: 1;
-          font-weight: bold;
-          padding: 12px;
-          background: rgba(0, 0, 0, 0.8);
-          color: #fff;
+          background: @text-color;
           border-radius: 2px;
+          color: @white;
+          font-family: @font-family;
+          line-height: 1;
+          margin-top: -7px;
+          padding: 12px;
+          transition: opacity .25s ease-in-out, color .25s ease-in-out;
 
           .tooltip-time {
-            font-size: 14px;
+            background: #3f3f3f;
+            color: @silver-chalice;
+            display: flex;
+            justify-content: center;
+            font-size: 11px;
+            text-align: center;
+            margin: -12px -12px 10px -12px;
+            padding: 6px 12px;
           }
+
+          .tooltip-list-item {
+            clear: both;
+            display: flex;
+            font-size: 14px;
+            margin: 10px 0;
+
+            &:last-of-type {
+                margin-bottom: 0;
+            }
+
+            &:only-of-type {
+                margin-top: 16px;
+            }
+
+            > * {
+                flex: 1 0 auto;
+            }
+          }
+
+          .tooltip-label {
+            color: @gallery;
+            font-weight: 300;
+          }
+
           .tooltip-value {
-            font-size: 12px;
+            text-align: right;
+            margin-left: 8px;
           }
         }
 
@@ -121,7 +165,7 @@
           font-size: 10px;
           width: 100%;
           line-height: 1;
-          color: rgba(0, 0, 0, 0.8);
+          color: @text-color;
           content: "\25BC";
           position: absolute;
           text-align: center;
@@ -129,7 +173,7 @@
 
         /* Style northward tooltips differently */
         .d3-tip.n:after {
-          margin: -1px 0 0 0;
+          margin: -3px 0 0 0;
           top: 100%;
           left: 0;
         }

--- a/addon/styles/variables.less
+++ b/addon/styles/variables.less
@@ -1,0 +1,14 @@
+@font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+@boulder: #7b7b7b;
+@dove-gray: #666;
+@gallery: #eee;
+@alto: #d1d1d1;
+@silver: #ccc;
+@silver-chalice: #aeaeae;
+@tundora: #4c4c4c;
+@white: #fff;
+@wild-sand: #f6f6f6;
+
+@background-color: @wild-sand;
+@text-color: @tundora;


### PR DESCRIPTION
## Before (dummy app)

<img width="1440" alt="chart-dummy-before" src="https://cloud.githubusercontent.com/assets/485903/24625650/b8fa40e2-187d-11e7-8232-0c12de6d0042.png">

## After (dummy app)

<img width="1440" alt="chart-dummy-after" src="https://cloud.githubusercontent.com/assets/485903/24625653/bba33af6-187d-11e7-9686-318828f9f7a5.png">

## Before (in app)

<img width="1440" alt="chart-in-app-before" src="https://cloud.githubusercontent.com/assets/485903/24625668/c6336c16-187d-11e7-96bc-53f18a7d4b66.png">

## After (in app)

<img width="1440" alt="chart-in-app-after" src="https://cloud.githubusercontent.com/assets/485903/24625674/c8435fe8-187d-11e7-936d-6f8c11aff17a.png">

Related PR: https://bitbucket.org/inindca/ember-engine-queues/pull-requests/313/adjust-bar-chart-colors-to-match-data-grid/diff