### PR TITLE
Max/min labels in the background of hatching

### DIFF
--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -48,7 +48,9 @@ export default BaseChartComponent.extend({
             })
             .x(d3.time.scale().domain(this.get('xAxis').domain))
             .xUnits(() => this.get('group')[0].size() * (this.get('group').length + 1))
-            .dimension(this.get('dimension'));
+            .dimension(this.get('dimension'))
+            .elasticY(true)
+            .yAxisPadding('40%');
 
         if (this.get('width')) {
             compositeChart.width(this.get('width'));
@@ -311,7 +313,7 @@ export default BaseChartComponent.extend({
 
         // Choose the tallest bar in the stack (lowest y value) and place the max/min labels above that.
         // Avoids label falling under any bar in the stack.
-        const maxLabelY = Math.min(...this.get('chart').selectAll(`.sub rect.bar:nth-of-type(${maxIdx + 1})`)[0].map(rect => parseInt(rect.getAttribute('y'), 10)));
+        const maxLabelY = Math.min(...this.get('chart').selectAll('.sub rect.bar')[0].map(rect => parseInt(rect.getAttribute('y'), 10)));
 
         if (b) {
             gLabels.append('text')

--- a/tests/dummy/public/data.json
+++ b/tests/dummy/public/data.json
@@ -31,7 +31,7 @@
   },
   {
     "date": 20161106,
-    "calls": 57,
+    "calls": 87,
     "chats": 14,
     "emails": 3
   },


### PR DESCRIPTION
fixing edge case where min label would be in background of hatching when other metrics were large relative to max/min metric.
also increasing axis padding on y axis in order to ensure that labels are shown when the bars are large