### PR TITLE
checking to see if element is destroyed on property change

### DIFF
--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -103,6 +103,10 @@ export default Component.extend({
     didReceiveAttrs() {
         this._super(...arguments);
 
+        if (this.get('isDestroyed') || this.get('isDestroying')) {
+            return;
+        }
+
         let data = {};
         _.forEach(this.get('group'), g => {
             _.forEach(g.all(), datum => {


### PR DESCRIPTION
couldn't reproduce error, but this _should_ make sure that when switching views, even if asynch requests are too slow the chart doesn't throw an error.