### PR TITLE
Adding check to code that is outside the runloop

### DIFF
--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -27,6 +27,11 @@ export default Component.extend({
 
     setupResize() {
         this.set('onResizeDebounced', () => {
+            // This is outside the Ember run loop so check if component is destroyed
+            if (this.get('isDestroyed') || this.get('isDestroying')) {
+                return;
+            }
+
             this.set('resizeTimer', debounce(this, this.createChart, 400, this.get('instantRun')));
         });
 


### PR DESCRIPTION
When I add a log message inside of the isDestroyed check it gets triggered sometimes when rapidly switching between analytics views. Some sort of race condition with the resize detector and embers willDestroy hook I think.