### PR TITLE
Only redraw a single chart instead of calling redrawAll

### DIFF
--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -2,7 +2,6 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { bind, debounce, cancel, scheduleOnce } from '@ember/runloop';
 import _ from 'lodash/lodash';
-import dc from 'dc';
 
 export default Component.extend({
     resizeDetector: service(),
@@ -130,7 +129,7 @@ export default Component.extend({
         scheduleOnce('afterRender', this, this.setupResize);
 
         if (this.get('chart')) {
-            dc.redrawAll();
+            this.get('chart').redraw();
         }
     }
 });


### PR DESCRIPTION
calling redrawAll when a charts parameters update seems like you would trigger unnecessary redraws if you are on a view with multiple charts. I didn't look too deeply into the docs tho so feel free to stand by the code that is already there