### PR TITLE
Fix tooltip sticking

### DIFF
--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -99,8 +99,9 @@ export default Component.extend({
                 .on('postRender', null);
         }
 
-        if (this.$() && this.$().parents() && !_.isEmpty(this.$().parents().find(`d3-tip #${this.get('elementId')}`))) {
-            this.$().parents().find(`.d3-tip #${this.get('elementId')}`).remove();
+        if (this.$() && this.$().parents() && !_.isEmpty(this.$().parents().find(`.d3-tip#${this.get('elementId')}`))) {
+            console.log('I did it');
+            this.$().parents().find(`.d3-tip#${this.get('elementId')}`).remove();
         }
     },
 

--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -100,7 +100,6 @@ export default Component.extend({
         }
 
         if (this.$() && this.$().parents() && !_.isEmpty(this.$().parents().find(`.d3-tip#${this.get('elementId')}`))) {
-            console.log('I did it');
             this.$().parents().find(`.d3-tip#${this.get('elementId')}`).remove();
         }
     },

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -136,19 +136,21 @@ export default BaseChartComponent.extend({
     createTooltip() {
         const formatter = this.get('xAxis.formatter') || (value => value);
         const titles = this.get('series').map(entry => entry.title);
-        let tip = d3.tip().attr('class', `d3-tip #${this.get('elementId')}`).html(d => {
-            if (!_.isEmpty(titles)) {
-                let str = `<span class="tooltip-time">${moment(d.data.key).format(this.get('tooltipDateFormat'))}</span>`;
-                titles.forEach((title, i) => {
-                    const datum = formatter(this.get('data')[d.data.key][i]);
-                    const secondaryClass = d.y === datum ? 'primary-stat' : '';
-                    str = str.concat(`<span class="tooltip-list-item"><span class="tooltip-label ${secondaryClass}">${title}</span><span class="tooltip-value ${secondaryClass}">${datum}</span></span>`);
-                });
-                return str;
-            }
+        let tip = d3.tip().attr('class', 'd3-tip')
+            .attr('id', this.get('elementId'))
+            .html(d => {
+                if (!_.isEmpty(titles)) {
+                    let str = `<span class="tooltip-time">${moment(d.data.key).format(this.get('tooltipDateFormat'))}</span>`;
+                    titles.forEach((title, i) => {
+                        const datum = formatter(this.get('data')[d.data.key][i]);
+                        const secondaryClass = d.y === datum ? 'primary-stat' : '';
+                        str = str.concat(`<span class="tooltip-list-item"><span class="tooltip-label ${secondaryClass}">${title}</span><span class="tooltip-value ${secondaryClass}">${datum}</span></span>`);
+                    });
+                    return str;
+                }
 
-            return `<span>${moment(d.data.key).format('L')}</span><br/><span class="tooltip-value">${d.data.value}</span>`;
-        });
+                return `<span>${moment(d.data.key).format('L')}</span><br/><span class="tooltip-value">${d.data.value}</span>`;
+            });
 
         return tip;
     },

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -92,19 +92,21 @@ export default BaseChartComponent.extend({
     createTooltip() {
         const formatter = this.get('xAxis.formatter') || (value => value);
         const titles = this.get('series').map(entry => entry.title);
-        let tip = d3.tip().attr('class', `d3-tip #${this.get('elementId')}`).html(d => {
-            if (!_.isEmpty(titles)) {
-                let str = `<span class="tooltip-time">${moment(d.data.key).format(this.get('tooltipDateFormat'))}</span>`;
-                titles.forEach((title, i) => {
-                    const datum = formatter(this.get('data')[d.data.key][i]);
-                    const secondaryClass = d.y === datum ? 'primary-stat' : '';
-                    str = str.concat(`<span class="tooltip-list-item"><span class="tooltip-label ${secondaryClass}">${title}</span><span class="tooltip-value ${secondaryClass}">${datum}</span></span>`);
-                });
-                return str;
-            }
+        let tip = d3.tip().attr('class', 'd3-tip')
+            .attr('id', this.get('elementId'))
+            .html(d => {
+                if (!_.isEmpty(titles)) {
+                    let str = `<span class="tooltip-time">${moment(d.data.key).format(this.get('tooltipDateFormat'))}</span>`;
+                    titles.forEach((title, i) => {
+                        const datum = formatter(this.get('data')[d.data.key][i]);
+                        const secondaryClass = d.y === datum ? 'primary-stat' : '';
+                        str = str.concat(`<span class="tooltip-list-item"><span class="tooltip-label ${secondaryClass}">${title}</span><span class="tooltip-value ${secondaryClass}">${datum}</span></span>`);
+                    });
+                    return str;
+                }
 
-            return `<span>${moment(d.data.key).format('L')}</span><br/><span class="tooltip-value">${d.data.value}</span>`;
-        });
+                return `<span>${moment(d.data.key).format('L')}</span><br/><span class="tooltip-value">${d.data.value}</span>`;
+            });
 
         return tip;
     },

--- a/addon/components/pie-chart/component.js
+++ b/addon/components/pie-chart/component.js
@@ -74,7 +74,7 @@ export default BaseChartComponent.extend({
     createTooltip() {
         return d3.tip()
             .attr('class', 'd3-tip pie-chart')
-            .attr('id', `${this.get('elementId')}`)
+            .attr('id', this.get('elementId'))
             .style('text-align', 'center')
             .html(d => {
                 return `<span class="pie-tip-key">${d.data.key}</span><br/><span class="pie-tip-value">${d.data.value}</span>`;

--- a/addon/components/row-chart/component.js
+++ b/addon/components/row-chart/component.js
@@ -68,8 +68,9 @@ export default BaseChartComponent.extend({
     },
 
     createTooltip() {
-        return d3.tip().attr('class', `d3-tip #${this.get('elementId')}`)
+        return d3.tip().attr('class', 'd3-tip')
             .style('text-align', 'center')
+            .attr('id', this.get('elementId'))
             .html(d => `<span class="row-tip-key">${d.key}</span><br/><span class="row-tip-value">${d.value}</span>`)
             .direction('e');
     },


### PR DESCRIPTION
When charts re-render, tooltips sometimes stick around because of some issues with classes vs ids on tooltips. This PR fixes that issue.