### PR TITLE
Change id to class

### DIFF
--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -298,7 +298,7 @@ export default BaseChartComponent.extend({
         const line = this.get('comparisonLine');
 
         this.get('chart').selectAll('.comparison-line').remove();
-        this.get('chart').selectAll('#comparison-text').remove();
+        this.get('chart').selectAll('.comparison-text').remove();
 
         chartBody.append('svg:line')
             .attr('x1', 100)
@@ -330,7 +330,7 @@ export default BaseChartComponent.extend({
             .attr('y', 14 + this.get('chart').y()(line.value))
             .attr('text-anchor', 'middle')
             .attr('font-size', '12px')
-            .attr('id', 'comparison-text')
+            .attr('class', 'comparison-text')
             .attr('fill', line.textColor || '#000000');
     },
 

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -175,7 +175,7 @@ export default BaseChartComponent.extend({
         const line = this.get('comparisonLine');
 
         this.get('chart').selectAll('.comparison-line').remove();
-        this.get('chart').selectAll('#comparison-text').remove();
+        this.get('chart').selectAll('.comparison-text').remove();
 
         chartBody.append('svg:line')
             .attr('x1', 100)
@@ -207,7 +207,7 @@ export default BaseChartComponent.extend({
             .attr('y', 14 + this.get('chart').y()(line.value))
             .attr('text-anchor', 'middle')
             .attr('font-size', '12px')
-            .attr('id', 'comparison-text')
+            .attr('class', 'comparison-text')
             .attr('fill', line.textColor || '#000000');
     },
 

--- a/addon/components/row-chart/component.js
+++ b/addon/components/row-chart/component.js
@@ -147,7 +147,7 @@ export default BaseChartComponent.extend({
         const line = this.get('comparisonLine');
 
         chart.selectAll('.comparison-line').remove();
-        chart.selectAll('#comparison-text').remove();
+        chart.selectAll('.comparison-text').remove();
         const lineG = chartBody.append('g').attr('class', 'comparisonLine');
 
         lineG.append('line')
@@ -180,7 +180,7 @@ export default BaseChartComponent.extend({
             .attr('x', chart.x()(line.value))
             .attr('text-anchor', 'middle')
             .attr('font-size', '12px')
-            .attr('id', 'comparison-text')
+            .attr('class', 'comparison-text')
             .attr('fill', line.textColor || '#000000');
     },
 


### PR DESCRIPTION
Change comparison text from id to class to avoid conflicts when multiple charts are on a page.