### PR TITLE
allow multiple comparison lines and alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ The column chart uses an *array* of crossfilter groups to display different type
 * `showMaxMin` (boolean): whether or not to show max/min indicators for the maximum and minimum values of one of the groups on the column chart
 * `seriesMaxMin` (index): index of `this.get('group')` to use to determine the maximum and minimum values (only used if `showMaxMin` is `true`)
 * `width` (number): width in pixels of chart. If not specified, the chart will fill to the width of its container.
-* `showComparisonLine` (boolean): whether or not to show a comparison line
-* `comparisonLine` (Object): a horizontal line to mark a target, average, or any kind of comparison value. Properties: 
-    * `value` (value on y axis on which to show line)
-    * `displayValue` (text that will appear to the left of the line on the y axis)
-    * `color` (Hex string)
+* `showComparisonLines` (boolean): whether or not to show the comparison lines
+* `comparisonLines` (Array of Objects): horizontal lines to mark a target, average, or any kind of comparison value. Properties: 
+    * `value` (number): value on y axis on which to show line
+    * `displayValue` (String): text that will appear to the left of the line on the y axis
+    * `color` (Hex string): color of the comparison line
+    * `alert` (String; acceptable values: `above`, `below`, `''`): whether to change the color of rectangles above or below this line. Use an empty string for no color changing.
+    * `alertColorIndex` (number): index of the `colors` array to use for color changes for this line.
 * `showCurrentIndicator` (boolean): whether or not to show diamond-shaped 'current' indicator on x axis
 * `currentInterval` (Object): MUST have a `start` property which contains a `moment` object that tells the chart where to display the current indicator.
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -59,7 +59,7 @@ export default Ember.Controller.extend({
 
     // color stuff
     heatColors: ['#203B73', '#75A8FF', '#8452CF', '#1DA8B3', '#B5B5EB', '#CC3EBE', '#5E5782', '#FF8FDD', '#868C1E', '#DDD933'],
-    colors: ['#B9B9B9', '#A0C0CF', '#105470', '#FF0000'],
+    colors: ['#B9B9B9', '#A0C0CF', '#105470', '#FF0000', '#0f9b22'],
     statusColors: [
         '#7ADB37', // available
         '#FC0D1C', // busy
@@ -83,9 +83,14 @@ export default Ember.Controller.extend({
 
     comparisonLine: { value: 50, displayValue: '50', color: '#2CD02C' },
 
+    comparisonLines:
+        [{ value: 75, displayValue: '75', color: '#FF0000', alert: 'above', alertColorIndex: 3 },
+            { value: 25, displayValue: '25', color: '#0f9b22', alert: 'below', alertColorIndex: 4 }
+        ],
+
     queueComparisonLine: { value: 225, displayValue: '225', color: '#2CD02C' },
 
-    series: [{ title: 'Skilled Answered Calls', hatch: 'pos' }, { title: 'Answered Calls', hatch: 'neg' }, { title: 'Offered Calls', hatch: false }, { title: 'pos alert hatch', hatch: 'pos', alert: true, replaceIndex: 0 }, { title: 'neg alert hatch', hatch: 'neg', alert: true, replaceIndex: 1 }],
+    series: [{ title: 'Skilled Answered Calls', hatch: 'pos' }, { title: 'Answered Calls', hatch: 'neg' }, { title: 'Offered Calls', hatch: false }],
 
     // format object tells the groups function how to interpret the data. Give the name of the property you want to use to assign a value to each bubble
     // e.g. the 'title' property is 'entity' here, which tells the grouping function that the 'entity' property on the data objects should be used for the displayed title on each bubble

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -20,7 +20,6 @@
 <button{{action "increaseData"}}>Increase</button>
 <button{{action "decreaseData"}}>Decrease</button><br/>
 {{input type='checkbox' checked=showColumnLegend}}Show Legend<br/>
-{{input type="text" value=alert}}Alert ('above' or 'below')<br/>
 
 {{column-chart
     dimension=dimensions
@@ -33,11 +32,10 @@
     height=200
     xAxis=xAxis
     yAxis=yAxis
-    showComparisonLine=true
-    comparisonLine=comparisonLine
+    showComparisonLines=true
+    comparisonLines=comparisonLines
     currentInterval=currentInterval
     showCurrentIndicator=true
-    alert=alert
     showLegend=showColumnLegend
     legendWidth=250
 }}

--- a/tests/integration/components/column-chart-test.js
+++ b/tests/integration/components/column-chart-test.js
@@ -64,11 +64,11 @@ const getTestParameters = function () {
             ticks: 3
         },
 
-        comparisonLine: {
+        comparisonLines: [{
             value: 15,
             displayValue: '15',
             color: '#2CD02C'
-        }
+        }]
     };
 };
 
@@ -112,8 +112,8 @@ test('it shows chart not available', function (assert) {
     return wait();
 });
 
-test('it shows a comparison line', function (assert) {
-    this.render(hbs`{{column-chart showComparisonLine=true comparisonLine=params.comparisonLine dimension=params.dimensions group=params.groups type=params.type series=params.series xAxis=params.xAxis yAxis=params.yAxis instantRun=true}}`);
+test('it shows comparison lines', function (assert) {
+    this.render(hbs`{{column-chart showComparisonLines=true comparisonLines=params.comparisonLines dimension=params.dimensions group=params.groups type=params.type series=params.series xAxis=params.xAxis yAxis=params.yAxis instantRun=true}}`);
     // delayed to let all dc rendering processes finish
     later(this, (() => assert.equal(this.$('.comparison-line').length, 3)), 1000);
     return wait();


### PR DESCRIPTION
Allows alerts above and below multiple comparison lines on the column chart. Changes `comparisonLine` param to `comparisonLines`, an array of the same object. Removes the need for the consumer to add extra series for alert values.