### PR TITLE
Exclude moment from ember-auto-import

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,16 @@ const LessCompiler = require('broccoli-less-single');
 module.exports = {
     name: require('./package').name,
 
+    options: {
+        autoImport: {
+            exclude: ['moment']
+        }
+    },
+
+    included() {
+        this._super.included.apply(this, arguments);
+    },
+
     isDevelopingAddon() {
         return Boolean(process.env.DATA_VIS_DEV_MODE);
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data-visualizations",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Ember addon to support visualizations with dc.js (d3 & crossfilter).",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
It looks like importing moment via ember-auto-import is causing moment to be defined on the window (with timezone support) rather than as an es6 module in another one of our dependencies. Excluding moment from ember-auto-import fixes it, though I'm not sure exactly what is going wrong here