### PR TITLE
Label adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ The column chart uses an *array* of crossfilter groups to display different type
 * `showComparisonLines` (boolean): whether or not to show the comparison lines
 * `comparisonLines` (Array of Objects): horizontal lines to mark a target, average, or any kind of comparison value. Properties: 
     * `value` (number): value on y axis on which to show line
-    * `displayValue` (String): text that will appear to the left of the line on the y axis
     * `color` (Hex string): color of the comparison line
-    * `textColor` (Hex string): color of the comparison line label
     * `alert` (String; acceptable values: `above`, `below`, `''`): whether to change the color of rectangles above or below this line. Use an empty string for no color changing.
     * `alertColorIndex` (number): index of the `colors` array to use for color changes for this line.
 * `showCurrentIndicator` (boolean): whether or not to show diamond-shaped 'current' indicator on x axis
@@ -79,9 +77,7 @@ The line chart uses an *array* of crossfilter groups to display different types 
 * `showComparisonLines` (boolean): whether or not to show the comparison lines
 * `comparisonLines` (Array of Objects): horizontal lines to mark a target, average, or any kind of comparison value. Properties: 
     * `value` (number): value on y axis on which to show line
-    * `displayValue` (String): text that will appear to the left of the line on the y axis
     * `color` (Hex string): color of the comparison line
-    * `textColor` (Hex string): color of the comparison line label
 * `showMaxMin` (boolean): whether or not to show max/min indicators for the maximum and minimum values of one of the groups on the line chart
 * `seriesMaxMin` (index): index of `this.get('group')` to use to determine the maximum and minimum values (only used if `showMaxMin` is `true`)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The column chart uses an *array* of crossfilter groups to display different type
     * `value` (number): value on y axis on which to show line
     * `displayValue` (String): text that will appear to the left of the line on the y axis
     * `color` (Hex string): color of the comparison line
+    * `textColor` (Hex string): color of the comparison line label
     * `alert` (String; acceptable values: `above`, `below`, `''`): whether to change the color of rectangles above or below this line. Use an empty string for no color changing.
     * `alertColorIndex` (number): index of the `colors` array to use for color changes for this line.
 * `showCurrentIndicator` (boolean): whether or not to show diamond-shaped 'current' indicator on x axis
@@ -80,6 +81,7 @@ The line chart uses an *array* of crossfilter groups to display different types 
     * `value` (number): value on y axis on which to show line
     * `displayValue` (String): text that will appear to the left of the line on the y axis
     * `color` (Hex string): color of the comparison line
+    * `textColor` (Hex string): color of the comparison line label
 * `showMaxMin` (boolean): whether or not to show max/min indicators for the maximum and minimum values of one of the groups on the line chart
 * `seriesMaxMin` (index): index of `this.get('group')` to use to determine the maximum and minimum values (only used if `showMaxMin` is `true`)
 

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -460,6 +460,10 @@ export default BaseChartComponent.extend({
         });
 
         for (let i = 0; i < bars.length; i++) {
+            if (!values[i]) {
+                continue;
+            }
+
             gLabels.append('text')
                 .text(() => formatter(values[i]))
                 .attr('x', () => +d3.select(bars[i]).attr('x') + (d3.select(bars[i]).attr('width') / 2))

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -6,6 +6,7 @@ import { isEmpty } from '@ember/utils';
 import d3Tip from 'd3-tip';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
+import { addComparisonLines } from 'ember-data-visualizations/utils/comparison-lines';
 
 /**
    @public
@@ -303,7 +304,7 @@ export default BaseChartComponent.extend({
         }
 
         if (!isEmpty(this.get('showComparisonLines')) && this.get('comparisonLines') && !isEmpty(this.get('data'))) {
-            this.addComparisonLines(chart);
+            addComparisonLines(chart, this.get('comparisonLines'));
         }
 
         if (this.get('showCurrentIndicator') && this.get('currentInterval')) {
@@ -391,51 +392,6 @@ export default BaseChartComponent.extend({
                 let tickHtml = this.isIntervalIncluded(xscaleTime.ticks(this.get('xAxis').ticks), indicatorDate) ? `\u25C6 ${currentTick.text()}` : '\u25C6';
                 currentTick.select('text').html(tickHtml);
             }
-        }
-    },
-
-    addComparisonLines(chart) {
-        const chartBody = chart.select('svg > g');
-        const lines = this.get('comparisonLines');
-
-        chart.selectAll('.comparison-line').remove();
-        chart.selectAll('.comparison-text').remove();
-
-        if (chartBody && chart && chart.y()) {
-            lines.forEach(line => {
-                chartBody.append('svg:line')
-                    .attr('x1', chart.margins().left)
-                    .attr('x2', chart.width() - chart.margins().right)
-                    .attr('y1', chart.margins().top + chart.y()(line.value))
-                    .attr('y2', chart.margins().top + chart.y()(line.value))
-                    .attr('class', 'comparison-line')
-                    .style('stroke', line.color || '#2CD02C');
-
-                chartBody.append('svg:line')
-                    .attr('x1', chart.margins().left)
-                    .attr('x2', chart.margins().left)
-                    .attr('y1', 15 + chart.y()(line.value))
-                    .attr('y2', 5 + chart.y()(line.value))
-                    .attr('class', 'comparison-line')
-                    .style('stroke', line.color || '#2CD02C');
-
-                chartBody.append('svg:line')
-                    .attr('x1', chart.width() - chart.margins().right)
-                    .attr('x2', chart.width() - chart.margins().right)
-                    .attr('y1', 15 + chart.y()(line.value))
-                    .attr('y2', 5 + chart.y()(line.value))
-                    .attr('class', 'comparison-line')
-                    .style('stroke', line.color || '#2CD02C');
-
-                chartBody.append('text')
-                    .text(line.displayValue)
-                    .attr('x', 80)
-                    .attr('y', 14 + chart.y()(line.value))
-                    .attr('text-anchor', 'middle')
-                    .attr('font-size', '12px')
-                    .attr('class', 'comparison-text')
-                    .attr('fill', line.textColor || '#000000');
-            });
         }
     },
 

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -6,7 +6,11 @@ import { isEmpty } from '@ember/utils';
 import d3Tip from 'd3-tip';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
-import { addComparisonLines } from 'ember-data-visualizations/utils/comparison-lines';
+
+import {
+    addComparisonLines,
+    addComparisonLineTicks
+} from 'ember-data-visualizations/utils/comparison-lines';
 
 /**
    @public
@@ -131,6 +135,8 @@ export default BaseChartComponent.extend({
             });
             columnCharts.push(columnChart);
         }
+
+        addComparisonLineTicks(compositeChart, this.get('comparisonLines'));
 
         compositeChart
             .on('pretransition', chart => this.onPretransition(chart, tip))

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -6,6 +6,7 @@ import { isEmpty } from '@ember/utils';
 import d3Tip from 'd3-tip';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
+import { addComparisonLines } from 'ember-data-visualizations/utils/comparison-lines';
 
 /**
    @public
@@ -136,8 +137,9 @@ export default BaseChartComponent.extend({
         }
 
         if (this.get('showComparisonLines') && this.get('comparisonLines') && !isEmpty(this.get('data'))) {
-            this.addComparisonLines(chart);
+            addComparisonLines(chart, this.get('comparisonLines'));
         }
+
         if (this.get('showCurrentIndicator') && this.get('currentInterval')) {
             this.changeTickForCurrentInterval();
         }
@@ -192,51 +194,6 @@ export default BaseChartComponent.extend({
                 let tickHtml = this.isIntervalIncluded(xTimeScale.ticks(this.get('xAxis').ticks), indicatorDate) ? `\u25C6 ${currentTick.text()}` : '\u25C6';
                 currentTick.select('text').html(tickHtml);
             }
-        }
-    },
-
-    addComparisonLines(chart) {
-        const chartBody = chart.select('svg > g');
-        const lines = this.get('comparisonLines');
-
-        chart.selectAll('.comparison-line').remove();
-        chart.selectAll('.comparison-text').remove();
-
-        if (chartBody && chart && chart.y()) {
-            lines.forEach(line => {
-                chartBody.append('svg:line')
-                    .attr('x1', chart.margins().left)
-                    .attr('x2', chart.width() - chart.margins().right)
-                    .attr('y1', chart.margins().top + chart.y()(line.value))
-                    .attr('y2', chart.margins().top + chart.y()(line.value))
-                    .attr('class', 'comparison-line')
-                    .style('stroke', line.color || '#2CD02C');
-
-                chartBody.append('svg:line')
-                    .attr('x1', chart.margins().left)
-                    .attr('x2', chart.margins().left)
-                    .attr('y1', 15 + chart.y()(line.value))
-                    .attr('y2', 5 + chart.y()(line.value))
-                    .attr('class', 'comparison-line')
-                    .style('stroke', line.color || '#2CD02C');
-
-                chartBody.append('svg:line')
-                    .attr('x1', chart.width() - chart.margins().right)
-                    .attr('x2', chart.width() - chart.margins().right)
-                    .attr('y1', 15 + chart.y()(line.value))
-                    .attr('y2', 5 + chart.y()(line.value))
-                    .attr('class', 'comparison-line')
-                    .style('stroke', line.color || '#2CD02C');
-
-                chartBody.append('text')
-                    .text(line.displayValue)
-                    .attr('x', 80)
-                    .attr('y', 14 + chart.y()(line.value))
-                    .attr('text-anchor', 'middle')
-                    .attr('font-size', '12px')
-                    .attr('class', 'comparison-text')
-                    .attr('fill', line.textColor || '#000000');
-            });
         }
     },
 

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -6,7 +6,11 @@ import { isEmpty } from '@ember/utils';
 import d3Tip from 'd3-tip';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
-import { addComparisonLines } from 'ember-data-visualizations/utils/comparison-lines';
+
+import {
+    addComparisonLines,
+    addComparisonLineTicks
+} from 'ember-data-visualizations/utils/comparison-lines';
 
 /**
    @public
@@ -86,6 +90,8 @@ export default BaseChartComponent.extend({
 
             lineCharts.push(lineChart);
         });
+
+        addComparisonLineTicks(compositeChart, this.get('comparisonLines'));
 
         compositeChart
             .on('renderlet', chart => this.onRenderlet(chart, tip))

--- a/addon/utils/chart-sizes.js
+++ b/addon/utils/chart-sizes.js
@@ -6,5 +6,7 @@ export default {
     RIGHT_MARGIN: 100,
     LEGEND_WIDTH: legendWidth,
     LEGEND_OFFSET: legendOffset,
-    LEGEND_RIGHT_MARGIN: legendWidth + legendOffset
+    LEGEND_RIGHT_MARGIN: legendWidth + legendOffset,
+    COMPARISON_LABEL_PAD: 5,
+    COMPARISON_LABEL_WIDTH: 40
 };

--- a/addon/utils/chart-sizes.js
+++ b/addon/utils/chart-sizes.js
@@ -6,7 +6,5 @@ export default {
     RIGHT_MARGIN: 100,
     LEGEND_WIDTH: legendWidth,
     LEGEND_OFFSET: legendOffset,
-    LEGEND_RIGHT_MARGIN: legendWidth + legendOffset,
-    COMPARISON_LABEL_PAD: 5,
-    COMPARISON_LABEL_WIDTH: 40
+    LEGEND_RIGHT_MARGIN: legendWidth + legendOffset
 };

--- a/addon/utils/comparison-lines.js
+++ b/addon/utils/comparison-lines.js
@@ -21,7 +21,7 @@ export function addComparisonLines(chart, comparisonLines) {
 
     comparisonLines.forEach(line => {
         const lineColor = line.color || '#2CD02C';
-        const lineXStart = ChartSizes.COMPARISON_LABEL_WIDTH;
+        const lineXStart = chart.margins().left;
         const lineXEnd = chart.width() - chart.margins().right;
         const lineY = chart.margins().top + chart.y()(line.value);
 
@@ -48,14 +48,30 @@ export function addComparisonLines(chart, comparisonLines) {
             .attr('y2', 5 + chart.y()(line.value))
             .attr('class', 'comparison-line comparison-line-right')
             .style('stroke', lineColor);
-
-        chartBody.append('text')
-            .text(line.displayValue)
-            .attr('x', lineXStart - ChartSizes.COMPARISON_LABEL_PAD)
-            .attr('y', 14 + chart.y()(line.value))
-            .attr('text-anchor', 'end')
-            .attr('font-size', '12px')
-            .attr('class', 'comparison-text')
-            .attr('fill', line.textColor || '#000000');
     });
+}
+
+/**
+   @desc Adds y-axis ticks for comparison line values to a column or line chart. These will replace any existing y-axis ticks.
+   @param {object} chart - DC chart instance.
+   @param {array} comparisonLines - Array of comparison lines passed to the chart component.
+*/
+export function addComparisonLineTicks(chart, comparisonLines) {
+    if (!chart || !comparisonLines) {
+        return;
+    }
+
+    const yAxis = chart.yAxis && chart.yAxis();
+
+    if (!yAxis) {
+        return;
+    }
+
+    const yAxisTicks = yAxis.ticks && yAxis.ticks();
+
+    if (!yAxisTicks) {
+        return;
+    }
+
+    yAxisTicks.tickValues(comparisonLines.map(line => line.value));
 }

--- a/addon/utils/comparison-lines.js
+++ b/addon/utils/comparison-lines.js
@@ -1,0 +1,61 @@
+import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
+
+/**
+   @desc Adds comparison lines to a line or column chart.
+   @param chart - DC chart instance.
+   @param comparisonLines - Array of comparison lines passed to the chart component.
+*/
+export function addComparisonLines(chart, comparisonLines) {
+    if (!chart || !comparisonLines) {
+        return;
+    }
+
+    const chartBody = chart.select('svg > g');
+
+    chart.selectAll('.comparison-line').remove();
+    chart.selectAll('.comparison-text').remove();
+
+    if (!(chartBody && chart && chart.y())) {
+        return;
+    }
+
+    comparisonLines.forEach(line => {
+        const lineColor = line.color || '#2CD02C';
+        const lineXStart = ChartSizes.COMPARISON_LABEL_WIDTH;
+        const lineXEnd = chart.width() - chart.margins().right;
+        const lineY = chart.margins().top + chart.y()(line.value);
+
+        chartBody.append('svg:line')
+            .attr('x1', lineXStart)
+            .attr('x2', lineXEnd)
+            .attr('y1', lineY)
+            .attr('y2', lineY)
+            .attr('class', 'comparison-line comparison-line-main')
+            .style('stroke', lineColor);
+
+        chartBody.append('svg:line')
+            .attr('x1', lineXStart)
+            .attr('x2', lineXStart)
+            .attr('y1', 15 + chart.y()(line.value))
+            .attr('y2', 5 + chart.y()(line.value))
+            .attr('class', 'comparison-line comparison-line-left')
+            .style('stroke', lineColor);
+
+        chartBody.append('svg:line')
+            .attr('x1', lineXEnd)
+            .attr('x2', lineXEnd)
+            .attr('y1', 15 + chart.y()(line.value))
+            .attr('y2', 5 + chart.y()(line.value))
+            .attr('class', 'comparison-line comparison-line-right')
+            .style('stroke', lineColor);
+
+        chartBody.append('text')
+            .text(line.displayValue)
+            .attr('x', lineXStart - ChartSizes.COMPARISON_LABEL_PAD)
+            .attr('y', 14 + chart.y()(line.value))
+            .attr('text-anchor', 'end')
+            .attr('font-size', '12px')
+            .attr('class', 'comparison-text')
+            .attr('fill', line.textColor || '#000000');
+    });
+}

--- a/app/utils/chart-sizes.js
+++ b/app/utils/chart-sizes.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-data-visualizations/utils/chart-sizes';

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -83,11 +83,9 @@ export default Controller.extend({
 
     currentInterval: { start: moment('12/02/2016') },
 
-    comparisonLine: { value: 50, displayValue: '50', color: '#2CD02C' },
-
     comparisonLines:
         [{ value: 75, displayValue: '75', color: '#FF0000', alert: 'above', alertColorIndex: 3 },
-            { value: 25, displayValue: '25', color: '#0f9b22', alert: 'below', alertColorIndex: 4 }
+            { value: 60, displayValue: '60', color: '#0f9b22', alert: 'below', alertColorIndex: 4 }
         ],
 
     queueComparisonLine: { value: 225, displayValue: '225', color: '#2CD02C' },

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -77,8 +77,7 @@ export default Controller.extend({
     },
     yAxis: {
         ticks: 3,
-        label: 'Queues',
-        formatter: value => value * 10
+        label: 'Queues'
     },
 
     currentInterval: { start: moment('12/02/2016') },

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -52,8 +52,8 @@
   height=200
   xAxis=xAxis
   yAxis=yAxis
-  showComparisonLine=true
-  comparisonLine=comparisonLine
+  showComparisonLines=true
+  comparisonLines=comparisonLines
   currentInterval=currentInterval
   showCurrentIndicator=false
   showLegend=showLineLegend

--- a/tests/integration/components/line-chart-test.js
+++ b/tests/integration/components/line-chart-test.js
@@ -64,11 +64,11 @@ const getTestParameters = function () {
             ticks: 3
         },
 
-        comparisonLine: {
+        comparisonLines: [{
             value: 15,
             displayValue: '15',
             color: '#2CD02C'
-        }
+        }]
     };
 };
 
@@ -106,7 +106,7 @@ test('it renders a point for each data point', function (assert) {
 });
 
 test('it shows a comparison line', function (assert) {
-    this.render(hbs`{{line-chart showComparisonLine=true comparisonLine=params.comparisonLine dimension=params.dimensions group=params.groups series=params.series xAxis=params.xAxis yAxis=params.yAxis instantRun=true}}`);
+    this.render(hbs`{{line-chart showComparisonLines=true comparisonLines=params.comparisonLines dimension=params.dimensions group=params.groups series=params.series xAxis=params.xAxis yAxis=params.yAxis instantRun=true}}`);
     // delayed to let all dc rendering processes finish
     later(this, () => assert.dom('.comparison-line').exists({ count: 3 }), 1000);
     return wait();


### PR DESCRIPTION
Do not show column chart labels for falsey values. Extend comparison lines to the left of the y axis to avoid collisions between axis and line labels.