### PR TITLE
Add d3 localization to column chart and line chart

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
         'ember/avoid-leaking-state-in-ember-objects': 'off',
         'arrow-parens': 'off',
         'one-var': 'off',
-        'indent': ['error', 4],
+        'indent': ['error', 4, { 'SwitchCase': 1, 'flatTernaryExpressions': true }],
         'space-before-function-paren': ['error', {
             'anonymous': 'always',
             'named': 'never'

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -27,7 +27,8 @@ export default BaseChartComponent.extend({
     currentInterval: null,
     showCurrentIndicator: false,
     maxMinSeries: null,
-    type: 'GROUPED', // GROUPED, LAYERED, STACKED
+    type: 'GROUPED', // GROUPED, LAYERED, STACKED,
+    d3LocaleInfo: {},
 
     buildChart() {
         let compositeChart = dc.compositeChart(`#${this.get('elementId')}`);

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -6,6 +6,7 @@ import { isEmpty } from '@ember/utils';
 import d3Tip from 'd3-tip';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
+import { getTickFormat } from 'ember-data-visualizations/utils/d3-localization';
 
 import {
     addComparisonLines,
@@ -70,6 +71,7 @@ export default BaseChartComponent.extend({
         }
 
         compositeChart.xAxis().tickSizeOuter(0);
+        compositeChart.xAxis().tickFormat(getTickFormat(this.get('d3LocaleInfo')));
         if (this.get('xAxis') && this.get('xAxis').ticks) {
             compositeChart.xAxis().ticks(this.get('xAxis').ticks);
         }

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -6,6 +6,7 @@ import { isEmpty } from '@ember/utils';
 import d3Tip from 'd3-tip';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
+import { getTickFormat } from 'ember-data-visualizations/utils/d3-localization';
 
 import {
     addComparisonLines,
@@ -26,6 +27,7 @@ export default BaseChartComponent.extend({
     currentInterval: null,
     showCurrentIndicator: false,
     maxMinSeries: null,
+    d3LocaleInfo: {},
 
     buildChart() {
         let compositeChart = dc.compositeChart(`#${this.get('elementId')}`);
@@ -63,6 +65,7 @@ export default BaseChartComponent.extend({
         }
 
         compositeChart.xAxis().tickSizeOuter(0);
+        compositeChart.xAxis().tickFormat(getTickFormat(this.get('d3LocaleInfo')));
         if (this.get('xAxis') && this.get('xAxis').ticks) {
             compositeChart.xAxis().ticks(this.get('xAxis').ticks);
         }

--- a/addon/utils/comparison-lines.js
+++ b/addon/utils/comparison-lines.js
@@ -1,5 +1,3 @@
-import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
-
 /**
    @desc Adds comparison lines to a line or column chart.
    @param chart - DC chart instance.

--- a/addon/utils/d3-localization.js
+++ b/addon/utils/d3-localization.js
@@ -1,0 +1,28 @@
+import moment from 'moment';
+import d3 from 'd3';
+
+export function getTickFormat({ periods = ['AM', 'PM'], dayFormat = '%a %d', weekFormat = '%d %b' }) {
+    let locale = d3.timeFormatLocale({
+        dateTime: '',
+        date: '',
+        time: '',
+        periods,
+        days: moment.weekdays(),
+        shortDays: moment.weekdaysShort(),
+        months: moment.months(),
+        shortMonths: moment.monthsShort()
+    });
+
+    let formatHour = locale.format('%I %p'),
+        formatDay = locale.format(dayFormat),
+        formatWeek = locale.format(weekFormat),
+        formatMonth = locale.format('%B'),
+        formatYear = locale.format('%Y');
+
+    return function (date) {
+        return (d3.timeDay(date) < date ? formatHour
+            : d3.timeMonth(date) < date ? (d3.timeWeek(date) < date ? formatDay : formatWeek)
+            : d3.timeYear(date) < date ? formatMonth
+            : formatYear)(date);
+    };
+}

--- a/addon/utils/d3-localization.js
+++ b/addon/utils/d3-localization.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import d3 from 'd3';
 
-export function getTickFormat({ periods = ['AM', 'PM'], dayFormat = '%a %d', weekFormat = '%d %b' }) {
+export function getTickFormat({ periods = ['AM', 'PM'], dayFormat = '%a %d', weekFormat = '%d %b', hourFormat = '%I %p' }) {
     let locale = d3.timeFormatLocale({
         dateTime: '',
         date: '',
@@ -13,7 +13,7 @@ export function getTickFormat({ periods = ['AM', 'PM'], dayFormat = '%a %d', wee
         shortMonths: moment.monthsShort()
     });
 
-    let formatHour = locale.format('%I %p'),
+    let formatHour = locale.format(hourFormat),
         formatDay = locale.format(dayFormat),
         formatWeek = locale.format(weekFormat),
         formatMonth = locale.format('%B'),

--- a/tests/integration/components/bubble-chart-test.js
+++ b/tests/integration/components/bubble-chart-test.js
@@ -70,7 +70,7 @@ test('it renders a subtitle for each data point', function (assert) {
 
 test('it renders a legend with the correct number of boxes', function (assert) {
     this.render(hbs`{{bubble-chart showLegend=true dimension=params.dimension group=params.group instantRun=true}}`);
-    later(this, () => assert.dom('g.legend > g.legendItem').exists({ count: 4 }), 1000);
+    later(this, () => assert.dom('.legend-container > .legend-item').exists({ count: 4 }), 1000);
     return wait();
 });
 

--- a/tests/integration/components/column-chart-test.js
+++ b/tests/integration/components/column-chart-test.js
@@ -137,7 +137,7 @@ test('it renders minimum and maximum value indicators', function (assert) {
 test('it renders a legend with the correct number of boxes', function (assert) {
     this.render(hbs`{{column-chart dimension=params.dimensions group=params.groups seriesData=params.seriesData type=params.type series=params.series xAxis=params.xAxis yAxis=params.yAxis showLegend=true instantRun=true}}`);
     // delayed to let all dc rendering processes finish
-    later(this, () => assert.dom('g.legend > g.legendItem').exists({ count: 3 }), 1000);
+    later(this, () => assert.dom('.legend-container > .legend-item').exists({ count: 3 }), 1000);
     return wait();
 });
 
@@ -145,6 +145,6 @@ test('it renders a legend even when there are no groups', function (assert) {
     this.set('groups', []);
     this.render(hbs`{{column-chart dimension=params.dimensions group=groups seriesData=params.seriesData type=params.type series=params.series xAxis=params.xAxis yAxis=params.yAxis showLegend=true instantRun=true}}`);
     // delayed to let all dc rendering processes finish
-    later(this, (() => assert.equal(this.$('g.legend > g.legendItem').length, 3)), 1000);
+    later(this, (() => assert.equal(this.$('.legend-container > .legend-item').length, 3)), 1000);
     return wait();
 });

--- a/tests/integration/components/heat-map-test.js
+++ b/tests/integration/components/heat-map-test.js
@@ -81,7 +81,7 @@ test('it renders correct number of x axis ticks', function (assert) {
 
 test('it renders a legend with the correct number of boxes', function (assert) {
     this.render(hbs`{{heat-map dimension=params.dimension group=params.group xAxis=params.xAxis yAxis=params.yAxis colorMap=params.colorMap keyFormat=params.keyFormat instantRun=true}}`);
-    later(this, () => assert.dom('g.legend > g.legendItem').exists({ count: 5 }), 1000);
+    later(this, () => assert.dom('.legend-container > .legend-item').exists({ count: 5 }), 1000);
     return wait();
 });
 

--- a/tests/integration/components/line-chart-test.js
+++ b/tests/integration/components/line-chart-test.js
@@ -115,7 +115,7 @@ test('it shows a comparison line', function (assert) {
 test('it renders a legend with the correct number of boxes', function (assert) {
     this.render(hbs`{{line-chart showLegend=true dimension=params.dimensions group=params.groups seriesData=params.seriesData series=params.series xAxis=params.xAxis yAxis=params.yAxis instantRun=true}}`);
     // delayed to let all dc rendering processes finish
-    later(this, () => assert.dom('g.legend > g.legendItem').exists({ count: 3 }), 1000);
+    later(this, () => assert.dom('.legend-container > .legend-item').exists({ count: 3 }), 1000);
     return wait();
 });
 
@@ -123,7 +123,7 @@ test('it renders a legend even when there are no groups', function (assert) {
     this.set('groups', []);
     this.render(hbs`{{line-chart showLegend=true dimension=params.dimensions group=groups seriesData=params.seriesData series=params.series xAxis=params.xAxis yAxis=params.yAxis instantRun=true}}`);
     // delayed to let all dc rendering processes finish
-    later(this, (() => assert.equal(this.$('g.legend > g.legendItem').length, 3)), 1000);
+    later(this, (() => assert.equal(this.$('.legend-container > .legend-item').length, 3)), 1000);
     return wait();
 });
 

--- a/tests/integration/components/pie-chart-test.js
+++ b/tests/integration/components/pie-chart-test.js
@@ -68,7 +68,7 @@ test('it shows chart not available', function (assert) {
 
 test('it renders a legend with the correct number of boxes', function (assert) {
     this.render(hbs`{{pie-chart dimension=params.dimensions group=params.groups showLegend=true instantRun=true}}`);
-    later(this, () => assert.dom('g.legend > g.legendItem').exists({ count: 4 }), 1000);
+    later(this, () => assert.dom('.legend-container > .legend-item').exists({ count: 4 }), 1000);
     return wait();
 });
 

--- a/tests/integration/components/row-chart-test.js
+++ b/tests/integration/components/row-chart-test.js
@@ -132,6 +132,6 @@ test('it shows a comparison line', function (assert) {
 test('it renders a legend with the correct number of boxes', function (assert) {
     this.render(hbs`{{row-chart showLegend=true dimension=params.dimensions group=params.groups xAxis=params.xAxis instantRun=true}}`);
     // delayed to let all dc rendering processes finish
-    later(this, () => assert.dom('g.legend > g.legendItem').exists({ count: 4 }), 1000);
+    later(this, () => assert.dom('.legend-container > .legend-item').exists({ count: 4 }), 1000);
     return wait();
 });


### PR DESCRIPTION
1. Localize month and day names using moment
2. Allow passing a `d3LocaleInfo` param to column chart and line chart with an options hash. 

```
{{column-chart
    d3LocaleInfo=d3LocaleInfo
    ....
}}
```

```
// example locale config
d3LocaleInfo: {
    hourFormat: '' // determine 24 hr vs. 12 hr time
    dayFormat: '', // determines wether to format "Thu 28" or "28 Thu"
    weekFormat: '', // determines wether to format "13 Feb" or "Feb 13"
    periods: ['AM', 'PM'] // AM/PM translations
}
```
hour, day and week format string syntax defined here https://github.com/d3/d3-time-format#locale_format