### PR TITLE
Engageui 2331 long column chart values overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ The column chart uses an *array* of crossfilter groups to display different type
 * `series` (Array):  Each object in the array has properties:
     * `title`: the name of `this.get('group')` at the same index (used in tooltip creation)
     * `hatch`: `pos` (for a hatch from bottom left to top right), `neg` (for a hatch from top left to bottom right), or `false` (for no hatch)
-* `LabelOptions`(Object): display options for labels on top of bars/columns.
+* `labelOptions`(Object): display options for labels on top of bars/columns.
     * `showMaxMin` (boolean): whether or not to show max/min indicators for the maximum and minimum values of one of the groups on the column chart.
     * `showDataValues` (boolean): whether or not to display the y-value of each point above each bar.
-    * `labelCollisionResolution` (boolean): runs collision detection algorithm to determine if a label is too wide, and skips next labels accordingly.
+    * `labelCollisionResolution` (string) ['auto' | 'default']: runs collision detection algorithm to determine if a label is too wide, and skips next labels accordingly.
 * `seriesMaxMin` (index): index of `this.get('group')` to use to determine the maximum and minimum values (only used if `showMaxMin` is `true`)
 * `width` (number): width in pixels of chart. If not specified, the chart will fill to the width of its container.
 * `showComparisonLines` (boolean): whether or not to show the comparison lines

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The column chart uses an *array* of crossfilter groups to display different type
 * `xAxis` (Object): `domain` (Array, probably of `moment` objects) and `ticks` (number of ticks to show)
 
 ##### Optional parameters
-* `yAxis` (Object): `domain` (Array, probably of numbers) (optional), `ticks` (number of ticks to show), and `formatter` (function to apply to every y-axis value for tick display)
+* `yAxis` (Object): `domain` (Array, probably of numbers) (optional): autofits bars, `ticks` (number of ticks to show), and `formatter` (function to apply to every y-axis value for tick display), `bottomLabelPosition` (boolean): whether to display labels on the top, or on the bottom of x-axis.
 * `type` (String) (defaults to `GROUPED`):
     * `GROUPED` is for "ordinary" data and is most likely what should be used if there is only one crossfilter group.
     * `LAYERED` is for "overlapping data: e.g. there are 10 fruits, 6 of which are citrus, 3 of which are oranges. If this chart is `LAYERED`, the `series` option tells the chart how to format the bars (hatching).
@@ -47,7 +47,10 @@ The column chart uses an *array* of crossfilter groups to display different type
 * `series` (Array):  Each object in the array has properties:
     * `title`: the name of `this.get('group')` at the same index (used in tooltip creation)
     * `hatch`: `pos` (for a hatch from bottom left to top right), `neg` (for a hatch from top left to bottom right), or `false` (for no hatch)
-* `showMaxMin` (boolean): whether or not to show max/min indicators for the maximum and minimum values of one of the groups on the column chart
+* `LabelOptions`(Object): display options for labels on top of bars/columns.
+    * `showMaxMin` (boolean): whether or not to show max/min indicators for the maximum and minimum values of one of the groups on the column chart.
+    * `showDataValues` (boolean): whether or not to display the y-value of each point above each bar.
+    * `labelCollisionResolution` (boolean): runs collision detection algorithm to determine if a label is too wide, and skips next labels accordingly.
 * `seriesMaxMin` (index): index of `this.get('group')` to use to determine the maximum and minimum values (only used if `showMaxMin` is `true`)
 * `width` (number): width in pixels of chart. If not specified, the chart will fill to the width of its container.
 * `showComparisonLines` (boolean): whether or not to show the comparison lines
@@ -58,7 +61,7 @@ The column chart uses an *array* of crossfilter groups to display different type
     * `alertColorIndex` (number): index of the `colors` array to use for color changes for this line.
 * `showCurrentIndicator` (boolean): whether or not to show diamond-shaped 'current' indicator on x axis
 * `currentInterval` (Object): MUST have a `start` property which contains a `moment` object that tells the chart where to display the current indicator.
-* `showDataValues` (boolean): whether or not to display the y-value of each point above each bar.
+
 
 ### Line chart
 The line chart uses an *array* of crossfilter groups to display different types of line charts. If there is only one group, *you must still pass an array of 1 group to the line chart*. This is true for many of the charts in this addon.

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -348,9 +348,12 @@ export default BaseChartComponent.extend({
          * Now, 'LAYERED' column-type is also added so that negative values are rendered in 'LAYERED' charts correctly.
          */
         if (negs && (['GROUPED', 'LAYERED'].indexOf(this.get('type').trim()) !== -1)) {
-            const y0 = chart.selectAll('rect.bar').filter(d => d.y <= 0).attr('y');
-            chart.select('.axis.x path.domain')
-                .attr('transform', `translate(0,${-1 * (this.get('height') - chart.margins().top - chart.margins().bottom - y0)})`);
+            const y0Chart = chart.selectAll('rect.bar').filter(d => d.y <= 0);
+            if (!y0Chart.empty()) {
+                const y0 = y0Chart.attr('y');
+                chart.select('.axis.x path.domain')
+                    .attr('transform', `translate(0,${-1 * (this.get('height') - chart.margins().top - chart.margins().bottom - y0)})`);
+            }
         }
     },
 

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -439,7 +439,7 @@ export default BaseChartComponent.extend({
         /* auto adjust when to hide data value of a bar
          * if labels overlap.
          */
-        if (this.get('labelOptions.labelCollisionResolution') === 'auto') {
+        if (this.get('labelOptions.labelCollisionResolution') === 'auto' && bars.length > 1) {
             const barWidth = Number(d3.select(bars[0]).attr('width'));
             const barGap = Math.abs(Number(d3.select(bars[0]).attr('x')) - Number(d3.select(bars[1]).attr('x'))) - barWidth;
 
@@ -462,7 +462,7 @@ export default BaseChartComponent.extend({
                 // if the label width swallows 'n' barwidth + bargap, then skip n iterations (or bars).
                 skipInterval = Math.ceil(labelWidth / (barWidth + barGap));
             }
-        } else if (this.get('labelOptions.labelCollisionResolution') === 'default') {
+        } else {
             for (let i = 0; i < bars.length; i++) {
                 if (!values[i]) {
                     continue;

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -457,7 +457,7 @@ export default BaseChartComponent.extend({
 
                 const label = gLabels.append('text')
                     .text(() => formatter(values[i]))
-                    .attr('x', () => d3.select(bars[i]).attr('x'))
+                    .attr('x', () => +d3.select(bars[i]).attr('x'))
                     .attr('y', Math.max(12, isBottomLabelPosition ? maxLabelYHeight + 12 : maxLabelY - 2))
                     .attr('font-size', '12px')
                     .attr('fill', this.getWithDefault('colors', [])[this.get('seriesMaxMin')])
@@ -486,7 +486,7 @@ export default BaseChartComponent.extend({
                 }
                 gLabels.append('text')
                     .text(() => formatter(values[i]))
-                    .attr('x', () => Number(d3.select(bars[i]).attr('x')) + Number((d3.select(bars[i]).attr('width')) / 2))
+                    .attr('x', () => +d3.select(bars[i]).attr('x') + Number((d3.select(bars[i]).attr('width')) / 2))
                     .attr('y', Math.max(12, isBottomLabelPosition ? maxLabelYHeight + 12 : maxLabelY - 2))
                     .attr('text-anchor', 'middle')
                     .attr('font-size', '12px')
@@ -533,8 +533,8 @@ export default BaseChartComponent.extend({
         if (b) {
             maxLabel = gLabels.append('text')
                 .text(maxValue)
-                .attr('x', Number(b.getAttribute('x')) + (useAutoCollisionResolution ? 0 : Number(b.getAttribute('width')) / 2))
-                .attr('y', Math.max(12, isBottomLabelPosition ? maxLabelYHeight + 12  : maxLabelY - 2))
+                .attr('x', +b.getAttribute('x') + (useAutoCollisionResolution ? 0 : Number(b.getAttribute('width')) / 2))
+                .attr('y', Math.max(12, isBottomLabelPosition ? maxLabelYHeight + 12 : maxLabelY - 2))
                 .attr('text-anchor', useAutoCollisionResolution ? 'left' : 'middle')
                 .attr('font-size', '12px')
                 .attr('fill', this.get('colors')[this.get('seriesMaxMin')])
@@ -546,7 +546,7 @@ export default BaseChartComponent.extend({
                     .html(() => '&#xf0d8')
                     .attr('text-anchor', useAutoCollisionResolution ? 'left' : 'middle')
                     .attr('class', 'caret-icon max-value-indicator')
-                    .attr('x', Number(b.getAttribute('x')) + (useAutoCollisionResolution ? 0 : Number(b.getAttribute('width')) / 2))
+                    .attr('x', +b.getAttribute('x') + (useAutoCollisionResolution ? 0 : Number(b.getAttribute('width')) / 2))
                     .attr('y', isBottomLabelPosition ? maxLabelYHeight + 24 : maxLabelY - 12);
             }
         }
@@ -555,7 +555,7 @@ export default BaseChartComponent.extend({
         if (b && !(maxIdx === minIdx)) {
             minLabel = gLabels.append('text')
                 .text(minValue)
-                .attr('x', Number(b.getAttribute('x')) + (useAutoCollisionResolution ? 0 : Number(b.getAttribute('width')) / 2))
+                .attr('x', +b.getAttribute('x') + (useAutoCollisionResolution ? 0 : Number(b.getAttribute('width')) / 2))
                 .attr('y', Math.max(12, isBottomLabelPosition ? maxLabelYHeight + 12 : maxLabelY - 2))
                 .attr('text-anchor', useAutoCollisionResolution ? 'left' : 'middle')
                 .attr('font-size', '12px')
@@ -567,7 +567,7 @@ export default BaseChartComponent.extend({
                 .html(() => '&#xf0d7')
                 .attr('class', 'caret-icon min-value-indicator')
                 .attr('text-anchor', useAutoCollisionResolution ? 'left' : 'middle')
-                .attr('x', Number(b.getAttribute('x')) + (useAutoCollisionResolution ? 0 : Number(b.getAttribute('width')) / 2))
+                .attr('x', +b.getAttribute('x') + (useAutoCollisionResolution ? 0 : Number(b.getAttribute('width')) / 2))
                 .attr('y', isBottomLabelPosition ? maxLabelYHeight + 24 : maxLabelY - 12);
         }
         const hasMaxLabel = maxLabel && !maxLabel.empty();

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -306,11 +306,11 @@ export default BaseChartComponent.extend({
             labels.remove();
         }
 
-        if (this.get('labelOptions.showDataValues') && typeof this.get('seriesMaxMin') === 'number' && bars.length > 0) {
+        if ((this.get('showDataValues') || this.get('labelOptions.showDataValues')) && typeof this.get('seriesMaxMin') === 'number' && bars.length > 0) {
             this.addDataValues(bars);
         }
 
-        if (this.get('labelOptions.showMaxMin') && typeof this.get('seriesMaxMin') === 'number' && bars.length > 0) {
+        if ((this.get('showMaxMin') || this.get('labelOptions.showMaxMin')) && typeof this.get('seriesMaxMin') === 'number' && bars.length > 0) {
             this.addMaxMinLabels(bars, chart);
         }
 
@@ -430,12 +430,11 @@ export default BaseChartComponent.extend({
             }
         });
 
+        /* auto adjust when to hide data value of a bar
+         * if labels overlap.
+         */
         if (this.get('labelOptions.labelCollisionResolution') === 'auto') {
-            /* auto adjust when to hide data vlue of a bar
-            * if labels overlap
-            */
             const barWidth = Number(d3.select(bars[0]).attr('width'));
-            // bar gap is differenct abscissa of one bar and  abscissa of next bar, minus the bar width.
             const barGap = Math.abs(Number(d3.select(bars[0]).attr('x')) - Number(d3.select(bars[1]).attr('x'))) - barWidth;
 
             // how many iterations to skip.
@@ -510,8 +509,6 @@ export default BaseChartComponent.extend({
         let raiseLabelBy = 0;
         if (this.get('labelOptions.labelCollisionResolution') === 'auto') {
             raiseLabelBy = 10;
-        } else if (this.get('labelOptions.labelCollisionResolution') === 'auto') {
-            raiseLabelBy = 0;
         }
         if (b) {
             chart.select(`#data-text-${maxIdx}`).remove();

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -426,7 +426,7 @@ export default BaseChartComponent.extend({
         const maxLabelY = Math.min(...yValues.y);
         const maxLabelYHeight = Math.max(...yValues.height);
         // to indicate if chart has all negative values, so that data labels could be rendered at negative side of x -axis.
-        const isBottomLabelPosition = this.get('yAxis').isisBottomLabelPosition;
+        const isBottomLabelPosition = this.get('yAxis').isBottomLabelPosition;
 
         let values = [];
         let groups = this.getWithDefault('group', []);
@@ -485,7 +485,7 @@ export default BaseChartComponent.extend({
         let maxValue, maxIdx, minValue, minIdx, values, nonZeroValues;
         let groups = this.get('group');
         // to indicate if chart has all negative values, so that max and min could be rendered at negative side of x -axis.
-        const isBottomLabelPosition = this.get('yAxis').isisBottomLabelPosition;
+        const isBottomLabelPosition = this.get('yAxis').isBottomLabelPosition;
         groups.forEach((g, index) => {
             if (index === this.get('seriesMaxMin')) {
                 values = g.all().map(gElem => gElem.value);

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -307,7 +307,7 @@ export default BaseChartComponent.extend({
         }
 
         if ((this.get('showDataValues') || this.get('labelOptions.showDataValues')) && typeof this.get('seriesMaxMin') === 'number' && bars.length > 0) {
-            this.addDataValues(bars);
+            this.addDataValues(bars, chart);
         }
 
         if ((this.get('showMaxMin') || this.get('labelOptions.showMaxMin')) && typeof this.get('seriesMaxMin') === 'number' && bars.length > 0) {
@@ -412,7 +412,7 @@ export default BaseChartComponent.extend({
         }
     },
 
-    addDataValues(bars = []) {
+    addDataValues(bars = [], chart) {
         let formatter = this.get('xAxis.formatter') || (value => value);
         let gLabels = d3.select(bars[0].parentNode).append('g').attr('id', 'data-labels');
 
@@ -445,6 +445,7 @@ export default BaseChartComponent.extend({
 
             // how many iterations to skip.
             let skipInterval = 1;
+            chart.dataLabels = Array(bars.length); // For internal use only, does not set controller property permanently.
             for (let i = 0; i < bars.length; i += skipInterval) {
                 if (!values[i]) {
                     continue;
@@ -458,6 +459,7 @@ export default BaseChartComponent.extend({
                     .attr('fill', this.getWithDefault('colors', [])[this.get('seriesMaxMin')])
                     .attr('class', 'data-text')
                     .attr('id', `data-text-${i}`);
+                chart.dataLabels[i] = label;
                 const labelWidth = label.node().getBoundingClientRect().width;
                 // if the label width swallows 'n' barwidth + bargap, then skip n iterations (or bars).
                 skipInterval = Math.ceil(labelWidth / (barWidth + barGap));
@@ -481,9 +483,9 @@ export default BaseChartComponent.extend({
     },
 
     addMaxMinLabels(bars, chart) {
-        let formatter = this.get('xAxis.formatter') || (value => value);
+        const formatter = this.get('xAxis.formatter') || (value => value);
         let maxValue, maxIdx, minValue, minIdx, values, nonZeroValues;
-        let groups = this.get('group');
+        const groups = this.get('group');
         // to indicate if chart has all negative values, so that max and min could be rendered at negative side of x -axis.
         const isBottomLabelPosition = this.get('yAxis').isBottomLabelPosition;
         groups.forEach((g, index) => {
@@ -498,7 +500,7 @@ export default BaseChartComponent.extend({
                 minValue = formatter(minValue);
             }
         });
-        let gLabels = d3.select(bars[0].parentNode).append('g').attr('class', 'inline-labels');
+        const gLabels = d3.select(bars[0].parentNode).append('g').attr('class', 'inline-labels');
         let b = bars[maxIdx];
 
         // Choose the tallest bar in the stack (lowest y value) and place the max/min labels above that.
@@ -511,21 +513,17 @@ export default BaseChartComponent.extend({
         const maxLabelY = Math.min(...yValues.y);
         const maxLabelYHeight = Math.max(...yValues.height);
 
-        // if label collision  detection is turned on, then raise the max and min labels slightly above data values.
-        let raiseLabelBy = 0;
-        if (this.get('labelOptions.labelCollisionResolution') === 'auto') {
-            raiseLabelBy = 10;
-        }
         if (b) {
             chart.select(`#data-text-${maxIdx}`).remove();
             gLabels.append('text')
                 .text(maxValue)
                 .attr('x', +b.getAttribute('x') + (b.getAttribute('width') / 2))
-                .attr('y', Math.max(12, isBottomLabelPosition ? maxLabelYHeight + 12 + raiseLabelBy : maxLabelY - 2 - raiseLabelBy))
+                .attr('y', Math.max(12, isBottomLabelPosition ? maxLabelYHeight + 12  : maxLabelY))
                 .attr('text-anchor', 'middle')
                 .attr('font-size', '12px')
                 .attr('fill', this.get('colors')[this.get('seriesMaxMin')])
-                .attr('class', 'max-value-text');
+                .attr('class', 'max-value-text')
+                .attr('id', `value-text-${maxIdx}`);
 
             if (!(maxIdx === minIdx)) {
                 gLabels.append('text')
@@ -534,9 +532,13 @@ export default BaseChartComponent.extend({
                     .attr('text-anchor', 'middle')
                     .attr('class', 'caret-icon max-value-indicator')
                     .attr('x', +b.getAttribute('x') + (b.getAttribute('width') / 2))
-                    .attr('y', isBottomLabelPosition ? maxLabelYHeight + 24 + raiseLabelBy : maxLabelY - 12 - raiseLabelBy);
+                    .attr('y', isBottomLabelPosition ? maxLabelYHeight + 24 : maxLabelY - 12);
+            }
+            if (this.get('labelOptions.labelCollisionResolution') === 'auto') {
+                adjustCollision(maxIdx, b);
             }
         }
+
         b = bars[minIdx];
 
         if (b && !(maxIdx === minIdx)) {
@@ -544,11 +546,12 @@ export default BaseChartComponent.extend({
             gLabels.append('text')
                 .text(minValue)
                 .attr('x', +b.getAttribute('x') + (b.getAttribute('width') / 2))
-                .attr('y', Math.max(12, isBottomLabelPosition ? maxLabelYHeight + 12 + raiseLabelBy : maxLabelY - 2 - raiseLabelBy))
+                .attr('y', Math.max(12, isBottomLabelPosition ? maxLabelYHeight + 12 : maxLabelY - 2))
                 .attr('text-anchor', 'middle')
                 .attr('font-size', '12px')
                 .attr('fill', this.get('colors')[this.get('seriesMaxMin')])
-                .attr('class', 'min-value-text');
+                .attr('class', 'min-value-text')
+                .attr('id', `value-text-${minIdx}`);
 
             gLabels.append('text')
                 // unicode for font-awesome caret down
@@ -556,7 +559,41 @@ export default BaseChartComponent.extend({
                 .attr('class', 'caret-icon min-value-indicator')
                 .attr('text-anchor', 'middle')
                 .attr('x', +b.getAttribute('x') + (b.getAttribute('width') / 2))
-                .attr('y', isBottomLabelPosition ? maxLabelYHeight + 24 + raiseLabelBy : maxLabelY - 12 - raiseLabelBy);
+                .attr('y', isBottomLabelPosition ? maxLabelYHeight + 24 : maxLabelY - 12);
+            if (this.get('labelOptions.labelCollisionResolution') === 'auto') {
+                adjustCollision(minIdx, b);
+            }
+        }
+
+        function adjustCollision(maxOrMinBarIndex, b) {
+            if (!maxOrMinBarIndex || maxOrMinBarIndex === -1 || bars.length <= 2) {
+                return;
+            }
+            const barWidth = Number(d3.select(bars[0]).attr('width'));
+            const barGap = Math.abs(Number(d3.select(bars[0]).attr('x')) - Number(d3.select(bars[1]).attr('x'))) - barWidth;
+
+            // get the nearest left hand side label of max or min value bar.
+            const leftNearestLabel = chart.dataLabels.slice(0, maxOrMinBarIndex).compact().pop();
+            // get all the right labels of max or min value bar.
+            const rightLabels = chart.dataLabels.slice(maxOrMinBarIndex, chart.dataLabels.length);
+
+            const maxOrMinBarLabel = chart.select(`#value-text-${maxOrMinBarIndex}`);
+
+            // left align the max/min label
+            maxOrMinBarLabel.attr('text-anchor', 'left')
+                .attr('x', b.getAttribute('x'));
+
+            if (leftNearestLabel && !leftNearestLabel.empty()) {
+                const { width, x } = leftNearestLabel.node().getBBox();
+                // if left nearest label collides with max/min label
+                if (width + x > maxOrMinBarLabel.node().getBBox().x) {
+                    leftNearestLabel.remove();
+                }
+            }
+            // number of right hand side labels to remove if min/max label appears to collide with right hand side labels.
+            const removeNrightLabels = Math.ceil(maxOrMinBarLabel.node().getBBox().width / (barWidth + barGap)) - 1;
+            rightLabels.slice(0, removeNrightLabels + 1).forEach(l => l.remove());
+
         }
     },
 

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -464,7 +464,7 @@ export default BaseChartComponent.extend({
                 }
                 gLabels.append('text')
                     .text(() => formatter(values[i]))
-                    .attr('x', () => d3.select(bars[i]).attr('x') + (d3.select(bars[i]).attr('width') / 2))
+                    .attr('x', () => Number(d3.select(bars[i]).attr('x')) + Number((d3.select(bars[i]).attr('width')) / 2))
                     .attr('y', Math.max(12, bottomLabelPosition ? maxLabelYHeight + 12 : maxLabelY - 2))
                     .attr('text-anchor', 'middle')
                     .attr('font-size', '12px')

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -521,9 +521,10 @@ export default BaseChartComponent.extend({
         const maxLabelY = Math.min(...yValues.y);
         const maxLabelYHeight = Math.max(...yValues.height);
 
+        let maxLabel, minLabel, minLabelIndicator;
         if (b) {
             chart.select(`#data-text-${maxIdx}`).remove();
-            gLabels.append('text')
+            maxLabel = gLabels.append('text')
                 .text(maxValue)
                 .attr('x', +b.getAttribute('x') + (this.get('labelOptions.labelCollisionResolution') === 'auto' ? 0 : (b.getAttribute('width') / 2)))
                 .attr('y', Math.max(12, isBottomLabelPosition ? maxLabelYHeight + 12  : maxLabelY - 2))
@@ -546,7 +547,7 @@ export default BaseChartComponent.extend({
 
         if (b && !(maxIdx === minIdx)) {
             chart.select(`#data-text-${minIdx}`).remove();
-            gLabels.append('text')
+            minLabel = gLabels.append('text')
                 .text(minValue)
                 .attr('x', +b.getAttribute('x') + (this.get('labelOptions.labelCollisionResolution') === 'auto' ? 0 : (b.getAttribute('width') / 2)))
                 .attr('y', Math.max(12, isBottomLabelPosition ? maxLabelYHeight + 12 : maxLabelY - 2))
@@ -555,13 +556,23 @@ export default BaseChartComponent.extend({
                 .attr('fill', this.get('colors')[this.get('seriesMaxMin')])
                 .attr('class', 'min-value-text');
 
-            gLabels.append('text')
+            minLabelIndicator = gLabels.append('text')
                 // unicode for font-awesome caret down
                 .html(() => '&#xf0d7')
                 .attr('class', 'caret-icon min-value-indicator')
                 .attr('text-anchor', this.get('labelOptions.labelCollisionResolution') === 'auto' ? 'left' : 'middle')
                 .attr('x', +b.getAttribute('x') + (this.get('labelOptions.labelCollisionResolution') === 'auto' ? 0 : (b.getAttribute('width') / 2)))
                 .attr('y', isBottomLabelPosition ? maxLabelYHeight + 24 : maxLabelY - 12);
+        }
+
+        // if max and min labels collide, then remove the minLabel.
+        if (this.get('labelOptions.labelCollisionResolution') === 'auto' && maxLabel && !maxLabel.empty() && minLabel && !minLabel.empty()) {
+            const minLabelDomesions = minLabel.node().getBBox(), maxLabelDimensions = maxLabel.node().getBBox();
+            if (Math.abs(minLabelDomesions.x - maxLabelDimensions.x) < minLabelDomesions.width) {
+                minLabel.remove();
+                minLabelIndicator.remove();
+            }
+
         }
     },
 

--- a/addon/utils/domain-tweaks.js
+++ b/addon/utils/domain-tweaks.js
@@ -31,6 +31,6 @@ export function addDomainTicks(chart, domain, otherTicks = []) {
  * @returns {*} a list [paddedlowerbound, paddedupperbound] : moves upper bound up and lower bound down (leaves 0 as it is).
  */
 export function padDomain(domain) {
-    const paddingFactor = 0.4;
+    const paddingFactor = 0.6;
     return domain.map(d => d * (1 + paddingFactor));
 }

--- a/tests/dummy/app/controllers/demo.js
+++ b/tests/dummy/app/controllers/demo.js
@@ -3,12 +3,13 @@ import Controller from '@ember/controller';
 import moment from 'moment';
 import d3 from 'd3';
 import crossfilter from 'crossfilter';
+import { computed } from '@ember/object';
 
 export default Controller.extend({
     metrics: [
         { value: 'sighting', label: 'Sightings' }
     ],
-
+    showCollisionDemo: false,
     actions: {
         increaseData() {
             let content = get(this, 'content');
@@ -85,6 +86,15 @@ export default Controller.extend({
                     data[20].calls  = 100.1155225544522;
                     break;
                 }
+                case 'minMaxOverlap': {
+                    data = this.get('content').map(d => {
+                        d.calls = 100;
+                        return d;
+                    });
+                    data[4].calls  = 99.323232323232;
+                    data[5].calls  = 201;
+                    break;
+                }
                 default: {
                     data = JSON.parse(this.data);
                 }
@@ -92,13 +102,18 @@ export default Controller.extend({
             this.set('content', data);
             this._createDimensions();
             this._createGroups();
+        },
+        toggleCollisionResolution() {
+            this.toggleProperty('showCollisionDemo');
         }
     },
-    labelOptions: {
-        showMaxMin: true,
-        showDataValues: true,
-        labelCollisionResolution: 'auto'
-    },
+    labelOptions: computed('showCollisionDemo', function () {
+        return {
+            showMaxMin: true,
+            showDataValues: true,
+            labelCollisionResolution: this.get('showCollisionDemo') ? 'auto' : 'default'
+        };
+    }),
 
     dimensions: [],
     domainString: '',

--- a/tests/dummy/app/controllers/demo.js
+++ b/tests/dummy/app/controllers/demo.js
@@ -52,6 +52,12 @@ export default Controller.extend({
             this._createQueueGroups();
         }
     },
+    labelOptions: {
+        showMaxMin: true,
+        showDataValues: true,
+        labelCollisionResolution: 'auto'
+    },
+
     dimensions: [],
     domainString: '',
     groups: [],

--- a/tests/dummy/app/controllers/demo.js
+++ b/tests/dummy/app/controllers/demo.js
@@ -50,6 +50,48 @@ export default Controller.extend({
             this.set('queueContent', content);
             this._createQueueDimensions();
             this._createQueueGroups();
+        },
+        doCollision(value) {
+            let data = [];
+            switch (value) {
+                case 'regLabelOverlappingMaxLabelLeft': {
+                    data = this.get('content').map(d => {
+                        d.calls = 100;
+                        return d;
+                    });
+                    data[18].calls  = 100.515151515151515151;
+                    break;
+                }
+                case 'regLabelNotOverlappingMaxLabelLeft': {
+                    data = this.get('content').map(d => {
+                        d.calls = 100;
+                        return d;
+                    });
+                    break;
+                }
+                case 'maxLabelOverlappingRegLabelLeft': {
+                    data = this.get('content').map(d => {
+                        d.calls = 100;
+                        return d;
+                    });
+                    data[19].calls  = 100.515151515151515151;
+                    break;
+                }
+                case 'maxLabelNotOverlappingRegLabelLeft': {
+                    data = this.get('content').map(d => {
+                        d.calls = 100;
+                        return d;
+                    });
+                    data[20].calls  = 100.1155225544522;
+                    break;
+                }
+                default: {
+                    data = JSON.parse(this.data);
+                }
+            }
+            this.set('content', data);
+            this._createDimensions();
+            this._createGroups();
         }
     },
     labelOptions: {
@@ -180,15 +222,7 @@ export default Controller.extend({
         content.forEach(function (d) {
             d.date = moment(d.date, 'YYYYMMDD').toDate();
         });
-
-        if (this._crossfilter) {
-            this._crossfilter.remove();
-            this._crossfilter.add(content);
-        } else {
-            this._crossfilter = crossfilter(content);
-        }
-
-        this.set('dimensions', this._crossfilter.dimension(d => d.date));
+        this.set('dimensions', crossfilter(content).dimension(d => d.date));
     },
 
     /**
@@ -214,6 +248,7 @@ export default Controller.extend({
 
         let self = this;
         d3.json('data.json').then(function (json) {
+            self.data = JSON.stringify(json);
             self.set('content', json);
             self._createDimensions();
             self._createGroups();

--- a/tests/dummy/app/templates/demo.hbs
+++ b/tests/dummy/app/templates/demo.hbs
@@ -21,12 +21,16 @@
 <button {{action "decreaseData"}}>Decrease</button><br>
 {{input type="checkbox" checked=showColumnLegend}}Show Legend<br>
 
-<h3> labelCollisionResolution </h3>
+<input type="checkbox" onchange={{action "toggleCollisionResolution"}} id="labelCollisionResolution"/> <label for="labelCollisionResolution"> labelCollisionResolution.</label>
+
+<h2> below cases {{if this.showCollisionDemo "with" "without" }} collision resolution.</h2>
+
 <input {{action "doCollision" "default"}} name="collision" type="radio" id="default"/><label for="default">Default.</label> <br>
-<input value="regLabelOverlappingMaxLabelLeft" {{action "doCollision" "regLabelOverlappingMaxLabelLeft"}} name="collision" type="radio" id="regLabelOverlappingMaxLabel_left"/><label for="regLabelOverlappingMaxLabel_left">When regular label overlapping max label from left.</label> <br>
-<input value="regLabelNotOverlappingMaxLabelLeft" {{action "doCollision" "regLabelNotOverlappingMaxLabelLeft"}} name="collision" type="radio" id="regLabelNotOverlappingMaxLabel_left"/><label for="regLabelNotOverlappingMaxLabel_left">When regular label not overlapping max label from left.</label> <br>
-<input value="maxLabelOverlappingRegLabelLeft" {{action "doCollision" "maxLabelOverlappingRegLabelLeft"}} name="collision" type="radio" id="maxLabelOverlappingRegLabel_left"/><label for="maxLabelOverlappingRegLabel_left">When max label overlapping regular label from left.</label> <br>
-<input value="maxLabelNotOverlappingRegLabelLeft" {{action "doCollision" "maxLabelNotOverlappingRegLabelLeft"}} name="collision" type="radio" id="maxLabelNotOverlappingRegLabel_left"/><label for="maxLabelNotOverlappingRegLabel_left">When max label not overlapping regular label from left.</label> <br>
+<input {{action "doCollision" "regLabelOverlappingMaxLabelLeft"}} name="collision" type="radio" id="regLabelOverlappingMaxLabel_left"/><label for="regLabelOverlappingMaxLabel_left">When regular label overlapping max label from left.</label> <br>
+<input {{action "doCollision" "regLabelNotOverlappingMaxLabelLeft"}} name="collision" type="radio" id="regLabelNotOverlappingMaxLabel_left"/><label for="regLabelNotOverlappingMaxLabel_left">When regular label not overlapping max label from left.</label> <br>
+<input {{action "doCollision" "maxLabelOverlappingRegLabelLeft"}} name="collision" type="radio" id="maxLabelOverlappingRegLabel_left"/><label for="maxLabelOverlappingRegLabel_left">When max label overlapping regular label from left.</label> <br>
+<input {{action "doCollision" "maxLabelNotOverlappingRegLabelLeft"}} name="collision" type="radio" id="maxLabelNotOverlappingRegLabel_left"/><label for="maxLabelNotOverlappingRegLabel_left">When max label not overlapping regular label from left.</label> <br>
+<input {{action "doCollision" "minMaxOverlap"}} name="collision" type="radio" id="minMaxOverlap"/><label for="minMaxOverlap">When max and min label overlap.</label> <br>
 
 {{column-chart
   dimension=dimensions

--- a/tests/dummy/app/templates/demo.hbs
+++ b/tests/dummy/app/templates/demo.hbs
@@ -21,6 +21,13 @@
 <button {{action "decreaseData"}}>Decrease</button><br>
 {{input type="checkbox" checked=showColumnLegend}}Show Legend<br>
 
+<h3> labelCollisionResolution </h3>
+<input {{action "doCollision" "default"}} name="collision" type="radio" id="default"/><label for="default">Default.</label> <br>
+<input value="regLabelOverlappingMaxLabelLeft" {{action "doCollision" "regLabelOverlappingMaxLabelLeft"}} name="collision" type="radio" id="regLabelOverlappingMaxLabel_left"/><label for="regLabelOverlappingMaxLabel_left">When regular label overlapping max label from left.</label> <br>
+<input value="regLabelNotOverlappingMaxLabelLeft" {{action "doCollision" "regLabelNotOverlappingMaxLabelLeft"}} name="collision" type="radio" id="regLabelNotOverlappingMaxLabel_left"/><label for="regLabelNotOverlappingMaxLabel_left">When regular label not overlapping max label from left.</label> <br>
+<input value="maxLabelOverlappingRegLabelLeft" {{action "doCollision" "maxLabelOverlappingRegLabelLeft"}} name="collision" type="radio" id="maxLabelOverlappingRegLabel_left"/><label for="maxLabelOverlappingRegLabel_left">When max label overlapping regular label from left.</label> <br>
+<input value="maxLabelNotOverlappingRegLabelLeft" {{action "doCollision" "maxLabelNotOverlappingRegLabelLeft"}} name="collision" type="radio" id="maxLabelNotOverlappingRegLabel_left"/><label for="maxLabelNotOverlappingRegLabel_left">When max label not overlapping regular label from left.</label> <br>
+
 {{column-chart
   dimension=dimensions
   group=groups

--- a/tests/dummy/app/templates/demo.hbs
+++ b/tests/dummy/app/templates/demo.hbs
@@ -21,16 +21,16 @@
 <button {{action "decreaseData"}}>Decrease</button><br>
 {{input type="checkbox" checked=showColumnLegend}}Show Legend<br>
 
-<input type="checkbox" onchange={{action "toggleCollisionResolution"}} id="labelCollisionResolution"/> <label for="labelCollisionResolution"> labelCollisionResolution.</label>
+<input type="checkbox" onchange={{action "toggleCollisionResolution"}} id="labelCollisionResolution"> <label for="labelCollisionResolution"> labelCollisionResolution.</label>
 
 <h2> below cases {{if this.showCollisionDemo "with" "without" }} collision resolution.</h2>
 
-<input {{action "doCollision" "default"}} name="collision" type="radio" id="default"/><label for="default">Default.</label> <br>
-<input {{action "doCollision" "regLabelOverlappingMaxLabelLeft"}} name="collision" type="radio" id="regLabelOverlappingMaxLabel_left"/><label for="regLabelOverlappingMaxLabel_left">When regular label overlapping max label from left.</label> <br>
-<input {{action "doCollision" "regLabelNotOverlappingMaxLabelLeft"}} name="collision" type="radio" id="regLabelNotOverlappingMaxLabel_left"/><label for="regLabelNotOverlappingMaxLabel_left">When regular label not overlapping max label from left.</label> <br>
-<input {{action "doCollision" "maxLabelOverlappingRegLabelLeft"}} name="collision" type="radio" id="maxLabelOverlappingRegLabel_left"/><label for="maxLabelOverlappingRegLabel_left">When max label overlapping regular label from left.</label> <br>
-<input {{action "doCollision" "maxLabelNotOverlappingRegLabelLeft"}} name="collision" type="radio" id="maxLabelNotOverlappingRegLabel_left"/><label for="maxLabelNotOverlappingRegLabel_left">When max label not overlapping regular label from left.</label> <br>
-<input {{action "doCollision" "minMaxOverlap"}} name="collision" type="radio" id="minMaxOverlap"/><label for="minMaxOverlap">When max and min label overlap.</label> <br>
+<input {{action "doCollision" "default"}} name="collision" type="radio" id="default"><label for="default">Default.</label> <br>
+<input {{action "doCollision" "regLabelOverlappingMaxLabelLeft"}} name="collision" type="radio" id="regLabelOverlappingMaxLabel_left"><label for="regLabelOverlappingMaxLabel_left">When regular label overlapping max label from left.</label> <br>
+<input {{action "doCollision" "regLabelNotOverlappingMaxLabelLeft"}} name="collision" type="radio" id="regLabelNotOverlappingMaxLabel_left"><label for="regLabelNotOverlappingMaxLabel_left">When regular label not overlapping max label from left.</label> <br>
+<input {{action "doCollision" "maxLabelOverlappingRegLabelLeft"}} name="collision" type="radio" id="maxLabelOverlappingRegLabel_left"><label for="maxLabelOverlappingRegLabel_left">When max label overlapping regular label from left.</label> <br>
+<input {{action "doCollision" "maxLabelNotOverlappingRegLabelLeft"}} name="collision" type="radio" id="maxLabelNotOverlappingRegLabel_left"><label for="maxLabelNotOverlappingRegLabel_left">When max label not overlapping regular label from left.</label> <br>
+<input {{action "doCollision" "minMaxOverlap"}} name="collision" type="radio" id="minMaxOverlap"><label for="minMaxOverlap">When max and min label overlap.</label> <br>
 
 {{column-chart
   dimension=dimensions

--- a/tests/dummy/app/templates/demo.hbs
+++ b/tests/dummy/app/templates/demo.hbs
@@ -26,7 +26,6 @@
   group=groups
   type="GROUPED"
   seriesMaxMin=0
-  showMaxMin=true
   series=oneSeries
   colors=colors
   height=200
@@ -38,7 +37,7 @@
   showCurrentIndicator=true
   showLegend=showColumnLegend
   legendWidth=250
-  showDataValues=true
+  labelOptions=labelOptions
 }}
 
 {{input type="checkbox" checked=showLineLegend}}Show Legend <br>

--- a/tests/integration/components/column-chart-test.js
+++ b/tests/integration/components/column-chart-test.js
@@ -231,12 +231,11 @@ module('Integration | Component | column chart - collision', function (hooks) {
                     instantRun=true
                 }}`);
         assert.equal([...document.querySelectorAll('.data-text')].map(d => d.innerHTML).indexOf('40.23232323232323'), -1, 'Expected chart does not have regular label if it overlaps max.');
-        assert.dom('.data-text').exists({ count: 2 }, 'Expected 5 data values to be rendered');
     });
 
-    test('removes any regular label if max overlaps that from the left', async function (assert) {
-        rawData[3].fruits = 40.23232323232323;
-        rawData[4].fruits = 45;
+    test('if max label overlaps the regular label from the left, remove the regular label.', async function (assert) {
+        rawData[3].fruits = 45.23232323232323;
+        rawData[4].fruits = 40;
         const dimAndGrp = createDimensionAndGroup(rawData);
         this.set('params.dimension', dimAndGrp.dimension);
         this.set('params.group', dimAndGrp.group);

--- a/tests/integration/components/column-chart-test.js
+++ b/tests/integration/components/column-chart-test.js
@@ -135,3 +135,194 @@ module('Integration | Component | column chart', function (hooks) {
         assert.dom('.legend-container > .legend-item').exists({ count: 3 });
     });
 });
+
+// collision detection test parameters
+const collisionTestParameters = function () {
+    return {
+        type: 'GROUPED',
+
+        series: [
+            {
+                title: 'Total Fruit Eaten'
+            }
+        ],
+
+        xAxis: {
+            domain: [
+                moment('2016-11-01'),
+                moment('2016-11-07')
+            ],
+            ticks: 5
+        },
+
+        yAxis: {
+            ticks: 3,
+            domain: [5, 55]
+        },
+
+        labelOptions: {
+            showMaxMin: true,
+            showDataValues: true,
+            labelCollisionResolution: 'auto'
+        }
+    };
+};
+
+const rawData = [
+    {
+        date: new Date('2016-11-02'),
+        fruits: 10
+    },
+    {
+        date: new Date('2016-11-03'),
+        fruits: 20
+    },
+    {
+        date: new Date('2016-11-04'),
+        fruits: 30
+    },
+    {
+        date: new Date('2016-11-05'),
+        fruits: 40
+    },
+    {
+        date: new Date('2016-11-06'),
+        fruits: 50
+    }
+];
+
+const createDimensionAndGroup = (data) => {
+    const dimension = crossfilter(data).dimension(d => d.date);
+    const group = [dimension.group().reduceSum(item => item.fruits)];
+    return {
+        dimension,
+        group
+    };
+};
+
+module('Integration | Component | column chart - collision', function (hooks) {
+    setupRenderingTest(hooks);
+    hooks.beforeEach(function () {
+        this.set('params', collisionTestParameters());
+        this.owner.register('service:resizeDetector', Service.extend({
+            setup(elementId, callback) {
+                callback();
+            },
+            teardown() {}
+        }));
+    });
+
+    test('removes any regular label that overlaps max from the left', async function (assert) {
+        rawData[3].fruits = 40.23232323232323;
+        const dimAndGrp = createDimensionAndGroup(rawData);
+        this.set('params.dimension', dimAndGrp.dimension);
+        this.set('params.group', dimAndGrp.group);
+        await render(
+            hbs `{{column-chart
+                    dimension=params.dimension
+                    group=params.group
+                    type=params.type
+                    seriesMaxMin=0
+                    series=params.series
+                    xAxis=params.xAxis
+                    yAxis=params.yAxis
+                    labelOptions=params.labelOptions
+                    height=200
+                    instantRun=true
+                }}`);
+        assert.equal([...document.querySelectorAll('.data-text')].map(d => d.innerHTML).indexOf('40.23232323232323'), -1, 'Expected chart does not have regular label if it overlaps max.');
+        assert.dom('.data-text').exists({ count: 2 }, 'Expected 5 data values to be rendered');
+    });
+
+    test('removes any regular label if max overlaps that from the left', async function (assert) {
+        rawData[3].fruits = 40.23232323232323;
+        rawData[4].fruits = 45;
+        const dimAndGrp = createDimensionAndGroup(rawData);
+        this.set('params.dimension', dimAndGrp.dimension);
+        this.set('params.group', dimAndGrp.group);
+        await render(
+            hbs `{{column-chart
+                    dimension=params.dimension
+                    group=params.group
+                    type=params.type
+                    seriesMaxMin=0
+                    series=params.series
+                    xAxis=params.xAxis
+                    yAxis=params.yAxis
+                    labelOptions=params.labelOptions
+                    height=200
+                    instantRun=true
+                }}`);
+        assert.equal([...document.querySelectorAll('.data-text')].map(d => d.innerHTML).indexOf('40.23232323232323'), -1, 'Expected chart does not have regular label if max overlaps it.');
+    });
+
+    test('do not remove any regular label if it does not overlap max', async function (assert) {
+        rawData[3].fruits = 40;
+        rawData[4].fruits = 50;
+        const dimAndGrp = createDimensionAndGroup(rawData);
+        this.set('params.dimension', dimAndGrp.dimension);
+        this.set('params.group', dimAndGrp.group);
+        await render(
+            hbs `{{column-chart
+                    dimension=params.dimension
+                    group=params.group
+                    type=params.type
+                    seriesMaxMin=0
+                    series=params.series
+                    xAxis=params.xAxis
+                    yAxis=params.yAxis
+                    labelOptions=params.labelOptions
+                    height=200
+                    instantRun=true
+                }}`);
+        assert.notEqual([...document.querySelectorAll('.data-text')].map(d => d.innerHTML).indexOf('40'), -1, 'Expected regular label that does not overlap max ');
+    });
+
+    test('remove any regular label if some other regular label overlaps it from left.', async function (assert) {
+        rawData[2].fruits = 30.2323232323232;
+        rawData[3].fruits = 40;
+        const dimAndGrp = createDimensionAndGroup(rawData);
+        this.set('params.dimension', dimAndGrp.dimension);
+        this.set('params.group', dimAndGrp.group);
+        await render(
+            hbs `{{column-chart
+                    dimension=params.dimension
+                    group=params.group
+                    type=params.type
+                    seriesMaxMin=0
+                    series=params.series
+                    xAxis=params.xAxis
+                    yAxis=params.yAxis
+                    labelOptions=params.labelOptions
+                    height=200
+                    instantRun=true
+                }}`);
+        assert.equal([...document.querySelectorAll('.data-text')].map(d => d.innerHTML).indexOf('40'), -1, 'Expected no regular label to the right of long label.');
+    });
+
+    test('remove min label and indicator if it overlaps max.', async function (assert) {
+        rawData[0].fruits = 41;
+        rawData[1].fruits = 42;
+        rawData[2].fruits = 40.2323232323232;
+        rawData[3].fruits = 50;
+        rawData[4].fruits = 49;
+        const dimAndGrp = createDimensionAndGroup(rawData);
+        this.set('params.dimension', dimAndGrp.dimension);
+        this.set('params.group', dimAndGrp.group);
+        await render(
+            hbs `{{column-chart
+                    dimension=params.dimension
+                    group=params.group
+                    type=params.type
+                    seriesMaxMin=0
+                    series=params.series
+                    xAxis=params.xAxis
+                    yAxis=params.yAxis
+                    labelOptions=params.labelOptions
+                    height=200
+                    instantRun=true
+                }}`);
+        assert.dom('.min-value-text').doesNotExist('Expected no min label');
+        assert.dom('.min-value-indicator').doesNotExist('Expected no min label indicator');
+    });
+});

--- a/tests/integration/components/column-chart-test.js
+++ b/tests/integration/components/column-chart-test.js
@@ -252,7 +252,7 @@ module('Integration | Component | column chart - collision', function (hooks) {
                     height=200
                     instantRun=true
                 }}`);
-        assert.equal([...document.querySelectorAll('.data-text')].map(d => d.innerHTML).indexOf('40.23232323232323'), -1, 'Expected chart does not have regular label if max overlaps it.');
+        assert.equal([...document.querySelectorAll('.data-text')].map(d => d.innerHTML).indexOf('40'), -1, 'Expected chart does not have regular label if max overlaps it.');
     });
 
     test('do not remove any regular label if it does not overlap max', async function (assert) {

--- a/tests/integration/components/pie-chart-test.js
+++ b/tests/integration/components/pie-chart-test.js
@@ -70,6 +70,6 @@ module('Integration | Component | pie chart', function (hooks) {
 
     test('it can show a total', async function (assert) {
         await render(hbs`{{pie-chart dimension=params.dimensions group=params.groups showTotal=true instantRun=true}}`);
-        assert.dom('text.totalText').exists();
+        assert.dom('.total-text-group').exists();
     });
 });


### PR DESCRIPTION
labelCollisionResolution property added that runs a collision detection algorithm and skips labels that are likely to collide dynamically.

properties like 'showMaxMin', 'showDataValues' and 'labelCollisionResolution' are combined into one property 'LabelOptions', description of these properties are added in the README markdown.

when this labelCollisionResolution mode operates, the labels next to wide labels are skipped to avoid collisions. The algorithm determines how many labels to skip. The Max and min values however are important data to show so, they are rendered at a different y alignment.

let W<sub>b</sub> = bar width, W<sub>g</sub> = width of space between bars and 

W<sub>label</sub> = width of the label, then 

Number of labels to skip ( N<sub>labels</sub> ) = CEIL(W<sub>label</sub> / ( W<sub>b</sub> + W<sub>g</sub>)) - 1

This algorithm calculates above number per iteration that does not skip a label, so this takes care of variable label width.

This is how it looks in the demo,
![Screen Shot 2019-06-03 at 11 55 55 AM](https://user-images.githubusercontent.com/42894144/58816669-f2e4ad80-85f7-11e9-82e0-376f507b7bce.png)

This is how it looked before,
![Screen Shot 2019-06-03 at 12 53 14 PM](https://user-images.githubusercontent.com/42894144/58819615-a0f35600-85fe-11e9-8c2d-df0f0218d44b.png)

Wrap-up view in the app, 
![Screen Shot 2019-06-03 at 2 02 10 PM](https://user-images.githubusercontent.com/42894144/58823777-7efed100-8608-11e9-81df-3fdef5b437e6.png)

Wrap-up view without 'labelCollisionResolution',
![Screen Shot 2019-06-03 at 2 03 44 PM](https://user-images.githubusercontent.com/42894144/58823806-8faf4700-8608-11e9-99a5-81eb6ab30c51.png)


## EDIT

The min and max labels now do not raise themselves.

the min/max labels are forced to show, any labels near them that tend to collide are removed.

~~Left nearest neighbour approach -~~
~~The nearest left hand side label of the min/max label is calculated, and based on collision detection algorithm, it is determined whether to remove that label or not.~~
~~if abcissa + width of neighbor label > abcissa of the min/max label, then the neighbor label is removed.~~

~~For right hand side neighbor labels, if the max/min label swallows the W<sub>b</sub> and W<sub>g</sub> by N number, then N labels to the right are removed.~~

![Screen Shot 2019-06-10 at 3 34 44 PM](https://user-images.githubusercontent.com/42894144/59221455-51300400-8b95-11e9-9924-e9431cef95f4.png)


~~PS: if min and max labels are adjacent, they will collide.~~

The max/min labels are rendered first, then data values are rendered. While rendering data values, the data value label and max/min label bounding box collision is detected, if they collide, the data value label is removed. If not, the data value label is tested with  CEIL(W<sub>label</sub> / ( W<sub>b</sub> + W<sub>g</sub>)) - 1 formula, to determine the next labels to skip.

The max and min labels themselves are tested by bounding box collision detection logic. If they two collide, the min label is removed.

bound-box collision detection logic - 

If the difference between abcissae of label<sub>1</sub> and label<sub>2</sub> is smaller than the width of label<sub>1</sub> or label<sub>2</sub> , then they are in collision (horizontal collision).