### PR TITLE
Engageui 2657 Pie chart tooltip disappears on hover

### DIFF
--- a/addon/components/pie-chart/component.js
+++ b/addon/components/pie-chart/component.js
@@ -139,6 +139,7 @@ export default BaseChartComponent.extend({
 
                 tip.style('top', (`${centerOfChartY + centroidY + offsetY}px`));
                 tip.style('left', (`${centerOfChartX + centroidX + offsetX}px`));
+                tip.style('pointer-events', 'none');
             })
             .on('mouseout.tip', function (d) {
                 tip.hide(d, this);


### PR DESCRIPTION
hovering on tooltip triggers mouseout event of pie/donut chart, that results in tooltip disappearing, changed 'pointer-events': none of tooltip element, so that no events would fire on tooltip hover.