### PR TITLE
Engageui 2659 background to piechart total

### DIFF
--- a/addon/components/pie-chart/component.js
+++ b/addon/components/pie-chart/component.js
@@ -59,6 +59,7 @@ export default BaseChartComponent.extend({
                 .attr('class', 'total-text-group')
                 .append('text')
                 .attr('class', 'total-text')
+                .attr('text-anchor', 'middle')
                 .text(this.get('data').total);
             const { x, y, width, height } = textLabel.node().getBBox(), padding = 6;
             chart.select('g.total-text-group').insert('rect', 'text.total-text')

--- a/addon/components/pie-chart/component.js
+++ b/addon/components/pie-chart/component.js
@@ -148,7 +148,6 @@ export default BaseChartComponent.extend({
 
                 tip.style('top', (`${centerOfChartY + centroidY + offsetY}px`));
                 tip.style('left', (`${centerOfChartX + centroidX + offsetX}px`));
-                tip.style('pointer-events', 'none');
             })
             .on('mouseout.tip', function (d) {
                 tip.hide(d, this);

--- a/addon/components/pie-chart/component.js
+++ b/addon/components/pie-chart/component.js
@@ -53,13 +53,22 @@ export default BaseChartComponent.extend({
     },
 
     onRenderlet(chart, tip) {
-        chart.select('g.pie-slice-group > .totalText').remove();
+        chart.select('g.pie-slice-group > .total-text-group').remove();
         if (this.get('showTotal')) {
-            chart.select('g.pie-slice-group')
+            const textLabel = chart.select('g.pie-slice-group').append('g')
+                .attr('class', 'total-text-group')
                 .append('text')
-                .attr('class', 'totalText')
-                .style('text-anchor', 'middle')
+                .attr('class', 'total-text')
                 .text(this.get('data').total);
+            const { x, y, width, height } = textLabel.node().getBBox(), padding = 6;
+            chart.select('g.total-text-group').insert('rect', 'text.total-text')
+                .attr('width', width + padding)
+                .attr('height', height + padding)
+                .attr('x', x - padding / 2)
+                .attr('y', y - padding / 2)
+                .attr('rx', '2')
+                .attr('ry', '2')
+                .attr('class', 'total-text-rect');
         }
 
         if (this.get('showLegend')) {

--- a/addon/components/pie-chart/component.js
+++ b/addon/components/pie-chart/component.js
@@ -139,6 +139,7 @@ export default BaseChartComponent.extend({
 
                 tip.style('top', (`${centerOfChartY + centroidY + offsetY}px`));
                 tip.style('left', (`${centerOfChartX + centroidX + offsetX}px`));
+                tip.style('pointer-events', 'none');
             })
             .on('mouseout.tip', function (d) {
                 tip.hide(d, this);

--- a/addon/components/pie-chart/style.less
+++ b/addon/components/pie-chart/style.less
@@ -21,6 +21,15 @@
     .dc-legend {
         cursor: default;
     }
+
+    .total-text-group {
+        .total-text-rect {
+            fill: @text-color;
+        }
+        .total-text {
+            fill: #fff;
+        }
+    }
 }
 .pie-chart.d3-tip:after {
     display: none;


### PR DESCRIPTION
added a rect behind the text with some padding and a fill color.

pie chart without this fix,
![Screen Shot 2019-06-04 at 11 01 10 AM](https://user-images.githubusercontent.com/42894144/58890161-196a1d80-86b8-11e9-9b54-b3afccaaa0c8.png)



pie chart with this fix,
![Screen Shot 2019-06-04 at 11 37 18 AM](https://user-images.githubusercontent.com/42894144/58892935-263d4000-86bd-11e9-96b0-13e39d8435f3.png)

