### PR TITLE
ENGAGEUI-2658 Add option to always show pie chart values

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The pie chart does *not* use an array of crossfilter groups. It uses a singular 
 * `donutChart` (boolean): whether or not this pie chart is a donut chart (has an inner radius)
 * `showTotal` (boolean): whether or not to show the total number in the center of the chart. Not recommended unless `donutChart` is `true`
 * `labels` (boolean): whether or not to show labels on the pie slices with the key value of the slice
+* `labelsWithValues` (boolean): whether or not to show values and labels both on the pie slices with the key value of the slice
 * `externalLabels` (boolean): whether or not the labels appear on the outside of the chart. Only if `labels` is `true`
 * `legend` (boolean): whether or not to show a legend for the pie chart
 

--- a/tests/dummy/app/templates/demo.hbs
+++ b/tests/dummy/app/templates/demo.hbs
@@ -64,6 +64,7 @@
 {{input type="checkbox" checked=donutChart}}Donut <br>
 {{input type="checkbox" checked=showTotal}}Total <br>
 {{input type="checkbox" checked=labels}}Labels <br>
+{{input type="checkbox" checked=labelsWithValues}}Labels With Values <br>
 {{input type="checkbox" checked=externalLabels}}External labels <br>
 {{input type="checkbox" checked=showPieLegend}}Show Legend <br>
 {{pie-chart
@@ -77,6 +78,7 @@
   donutChart=donutChart
   externalLabels=externalLabels
   labels=labels
+  labelsWithValues=labelsWithValues
   showLegend=showPieLegend
   legendWidth=200
 }}


### PR DESCRIPTION
Added a new option in pie chart widget that shows labels along with the values.

Only Labels,

![Screen Shot 2019-06-04 at 3 42 11 PM](https://user-images.githubusercontent.com/42894144/58908739-5eee1100-86df-11e9-80ea-0fde4adc2eed.png)


Values With Labels,

![Screen Shot 2019-06-04 at 3 42 59 PM](https://user-images.githubusercontent.com/42894144/58908767-74fbd180-86df-11e9-9307-01cd6b890a12.png)
