### PR TITLE
Memory leak fixes

### DIFF
--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -1,9 +1,11 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { bind, debounce, cancel, scheduleOnce } from '@ember/runloop';
+import { computed } from '@ember/object';
 import { A } from '@ember/array';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
+import dc from 'dc';
 
 export default Component.extend({
     resizeDetector: service(),
@@ -34,6 +36,10 @@ export default Component.extend({
         ABOVE: 'above',
         BELOW: 'below'
     },
+
+    uniqueChartGroupName: computed('elementId', function () {
+        return `chart-group-${this.get('elementId')}`;
+    }),
 
     /**
        @desc Retrieves the color at the given index. Just returns the last available color if index is out of bounds of the array.
@@ -214,6 +220,7 @@ export default Component.extend({
         this._super(...arguments);
         this.tearDownResize();
         this.cancelTimers();
+        dc.chartRegistry.clear(this.get('uniqueChartGroupName'));
     },
 
     didReceiveAttrs() {

--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -72,22 +72,31 @@ export default Component.extend({
         cancel(this.get('resizeTimer'));
     },
 
-    addClickHandlersAndTooltips(svg, tip, elementToApplyTip) {
+    addClickHandlersAndTooltips(svg, tip) {
         if (tip && !svg.empty()) {
             svg.call(tip);
         }
         // clicking actions
-        this.get('chart').selectAll(elementToApplyTip).on('click', d => {
+        this.get('chart').selectAll(this.elementToApplyTipSelector).on('click', d => {
             this.onClick(d);
         });
 
-        this.get('chart').selectAll(elementToApplyTip)
+        this.get('chart').selectAll(this.elementToApplyTipSelector)
             .on('mouseover.tip', function (d) {
                 tip.show(d, this);
             })
             .on('mouseout.tip', function (d) {
                 tip.hide(d, this);
             });
+    },
+
+    removeClickHandlersAndTooltips() {
+        // clicking actions
+        this.get('chart').selectAll(this.elementToApplyTipSelector).on('click', null);
+
+        this.get('chart').selectAll(this.elementToApplyTipSelector)
+            .on('mouseover.tip', null)
+            .on('mouseout.tip', null);
     },
 
     addLegend(chart, legendables, legendG, legendDimension, legendWidth) {
@@ -205,19 +214,22 @@ export default Component.extend({
 
     cleanupCurrentChart() {
         if (this.get('chart')) {
+            this.removeClickHandlersAndTooltips(this.elementToApplyTipSelector);
             this.get('chart')
                 .on('renderlet', null)
                 .on('postRender', null);
         }
-
-        let tooltips = document.querySelector(`.d3-tip#${this.get('elementId')}`);
-        if (tooltips) {
-            tooltips.remove();
+        let tooltips = document.querySelectorAll(`.d3-tip.${this.get('elementId')}`);
+        if (tooltips && tooltips.length) {
+            tooltips.forEach(tooltip => {
+                tooltip.remove();
+            });
         }
     },
 
     willDestroyElement() {
         this._super(...arguments);
+        this.cleanupCurrentChart();
         this.tearDownResize();
         this.cancelTimers();
         dc.chartRegistry.clear(this.get('uniqueChartGroupName'));

--- a/addon/components/bubble-chart/component.js
+++ b/addon/components/bubble-chart/component.js
@@ -13,6 +13,7 @@ import bubbleCloud from 'dc-addons-bubble-chart';
 */
 export default BaseChartComponent.extend({
     classNames: ['bubble-chart'],
+    elementToApplyTipSelector: 'circle.bubble',
 
     buildChart() {
         let bubbleChart = bubbleCloud(`#${this.get('elementId')}`);
@@ -81,7 +82,7 @@ export default BaseChartComponent.extend({
             this.addLegend(chart, this.getLegendables(chart), legendG, legendDimension);
         }
 
-        this.addClickHandlersAndTooltips(chart.select('svg'), tip, 'circle.bubble');
+        this.addClickHandlersAndTooltips(chart.select('svg'), tip);
     },
 
     getLegendables(chart) {
@@ -101,8 +102,7 @@ export default BaseChartComponent.extend({
     },
 
     createTooltip() {
-        return d3Tip().attr('class', 'd3-tip')
-            .attr('id', this.get('elementId'))
+        return d3Tip().attr('class', `d3-tip ${this.get('elementId')}`)
             .style('text-align', 'center')
             .html(d => `<span class="tooltip-value">${d.key}</span><br/><span class="tooltip-label">${d.value.tooltip}</span>`);
     },

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -7,12 +7,9 @@ import d3Tip from 'd3-tip';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
 import { getTickFormat } from 'ember-data-visualizations/utils/d3-localization';
-
-import {
-    addComparisonLines,
-    addComparisonLineTicks
-} from 'ember-data-visualizations/utils/comparison-lines';
+import { addComparisonLines, addComparisonLineTicks } from 'ember-data-visualizations/utils/comparison-lines';
 import { padDomain, addDomainTicks } from 'ember-data-visualizations/utils/domain-tweaks';
+
 /**
    @public
    @module column-chart
@@ -29,6 +26,7 @@ export default BaseChartComponent.extend({
     maxMinSeries: null,
     type: 'GROUPED', // GROUPED, LAYERED, STACKED,
     d3LocaleInfo: {},
+    elementToApplyTipSelector: 'rect.bar',
 
     buildChart() {
         let compositeChart = dc.compositeChart(`#${this.get('elementId')}`, this.get('uniqueChartGroupName'));
@@ -152,8 +150,7 @@ export default BaseChartComponent.extend({
     createTooltip() {
         const formatter = this.get('xAxis.formatter') || (value => value);
         const titles = this.getWithDefault('series', []).map(entry => entry.title);
-        let tip = d3Tip().attr('class', 'd3-tip')
-            .attr('id', this.get('elementId'))
+        let tip = d3Tip().attr('class', `d3-tip ${this.get('elementId')}`)
             .html(d => {
                 if (!isEmpty(titles)) {
                     let str = `<span class="tooltip-time">${moment(d.data.key).format(this.get('tooltipDateFormat'))}</span>`;
@@ -299,7 +296,7 @@ export default BaseChartComponent.extend({
         let svg = chart.select('svg > defs');
         let bars = chart.selectAll('.sub._0 rect.bar')._groups[0];
 
-        this.addClickHandlersAndTooltips(svg, tip, 'rect.bar');
+        this.addClickHandlersAndTooltips(svg, tip);
 
         let labels = document.querySelector(`#${this.get('elementId')} .inline-labels`);
         if (labels) {

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -31,7 +31,7 @@ export default BaseChartComponent.extend({
     d3LocaleInfo: {},
 
     buildChart() {
-        let compositeChart = dc.compositeChart(`#${this.get('elementId')}`);
+        let compositeChart = dc.compositeChart(`#${this.get('elementId')}`, this.get('uniqueChartGroupName'));
 
         const legendWidth = this.get('legendWidth') || ChartSizes.LEGEND_WIDTH;
         const rightMargin = this.get('showLegend') ? ChartSizes.LEGEND_OFFSET + legendWidth : ChartSizes.RIGHT_MARGIN;
@@ -94,7 +94,7 @@ export default BaseChartComponent.extend({
             groups.forEach((g, index) => {
                 // If we are hatching, we need to display a white bar behind the hatched bar
                 if (!isEmpty(this.get('series')) && !isEmpty(this.get('series')[index]) && this.get('series')[index].hatch) {
-                    columnChart = dc.barChart(compositeChart);
+                    columnChart = dc.barChart(compositeChart, this.get('uniqueChartGroupName'));
 
                     columnChart
                         .centerBar(true)
@@ -107,7 +107,7 @@ export default BaseChartComponent.extend({
                     columnCharts.push(columnChart);
                 }
 
-                columnChart = dc.barChart(compositeChart);
+                columnChart = dc.barChart(compositeChart, this.get('uniqueChartGroupName'));
 
                 columnChart
                     .centerBar(true)
@@ -124,7 +124,7 @@ export default BaseChartComponent.extend({
                 columnCharts.push(columnChart);
             });
         } else {
-            columnChart = dc.barChart(compositeChart);
+            columnChart = dc.barChart(compositeChart, this.get('uniqueChartGroupName'));
             columnChart
                 .centerBar(true)
                 .barPadding(0.00)
@@ -599,7 +599,7 @@ export default BaseChartComponent.extend({
         const xAxis = this.get('xAxis');
         const yAxis = this.get('yAxis');
 
-        let columnChart = dc.barChart(`#${this.get('elementId')}`);
+        let columnChart = dc.barChart(`#${this.get('elementId')}`, this.get('uniqueChartGroupName'));
         this.set('chart', columnChart);
 
         const duration = moment.duration(xAxis.domain[1].diff(xAxis.domain[0]));

--- a/addon/components/heat-map/component.js
+++ b/addon/components/heat-map/component.js
@@ -14,6 +14,7 @@ import d3 from 'd3';
 export default BaseChartComponent.extend({
     classNames: ['heat-map'],
 
+    elementToApplyTipSelector: 'rect.heat-box',
     currentInterval: null,
     showCurrentIndicator: false,
     valueFormat: v => v,
@@ -92,8 +93,7 @@ export default BaseChartComponent.extend({
     },
 
     createTooltip() {
-        return d3Tip().attr('class', 'd3-tip')
-            .attr('id', this.get('elementId'))
+        return d3Tip().attr('class', `d3-tip ${this.get('elementId')}`)
             .style('text-align', 'center')
             .html(d => `<span class='row-tip-key'>${d.key[0] ? `${d.key[0]}, ` : ''} ${this.get('keyFormat')(d.key[1])}</span><br/><span class='row-tip-value'>${this.get('valueFormat')(d.value)}</span>`);
     },
@@ -275,7 +275,7 @@ export default BaseChartComponent.extend({
     },
 
     onRenderlet(tip) {
-        this.addClickHandlersAndTooltips(this.get('chart').select('svg'), tip, 'rect.heat-box');
+        this.addClickHandlersAndTooltips(this.get('chart').select('svg'), tip);
     },
 
     showChartNotAvailable() {

--- a/addon/components/heat-map/component.js
+++ b/addon/components/heat-map/component.js
@@ -20,7 +20,7 @@ export default BaseChartComponent.extend({
     colorMap: v => v,
 
     buildChart() {
-        let heatMap = dc.heatMap(`#${this.get('elementId')}`);
+        let heatMap = dc.heatMap(`#${this.get('elementId')}`, this.get('uniqueChartGroupName'));
 
         if (!this.get('xAxis') || !this.get('xAxis').domain) {
             return;
@@ -284,7 +284,7 @@ export default BaseChartComponent.extend({
         const chartNotAvailableTextColor = this.get('chartNotAvailableTextColor');
         const xAxis = this.get('xAxis');
 
-        let heatMap = dc.heatMap(`#${this.get('elementId')}`);
+        let heatMap = dc.heatMap(`#${this.get('elementId')}`, this.get('uniqueChartGroupName'));
         this.set('chart', heatMap);
         const rightMargin = this.get('legend') && this.get('legendWidth') ? this.get('legendWidth') : 5;
 

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -30,7 +30,7 @@ export default BaseChartComponent.extend({
     d3LocaleInfo: {},
 
     buildChart() {
-        let compositeChart = dc.compositeChart(`#${this.get('elementId')}`);
+        let compositeChart = dc.compositeChart(`#${this.get('elementId')}`, this.get('uniqueChartGroupName'));
 
         const legendWidth = this.get('legendWidth') || ChartSizes.LEGEND_WIDTH;
         const rightMargin = this.get('showLegend') ? ChartSizes.LEGEND_OFFSET + legendWidth : ChartSizes.RIGHT_MARGIN;
@@ -83,7 +83,7 @@ export default BaseChartComponent.extend({
         let tip = this.createTooltip();
 
         this.get('group').forEach((g, index) => {
-            lineChart = dc.lineChart(compositeChart);
+            lineChart = dc.lineChart(compositeChart, this.get('uniqueChartGroupName'));
 
             lineChart
                 .group(g)
@@ -283,7 +283,7 @@ export default BaseChartComponent.extend({
         const xAxis = this.get('xAxis');
         const yAxis = this.get('yAxis');
 
-        let compositeChart = dc.compositeChart(`#${this.get('elementId')}`);
+        let compositeChart = dc.compositeChart(`#${this.get('elementId')}`, this.get('uniqueChartGroupName'));
 
         compositeChart
             .colors(chartNotAvailableColor)
@@ -332,7 +332,7 @@ export default BaseChartComponent.extend({
         let lineChart;
 
         groups.forEach((g) => {
-            lineChart = dc.lineChart(compositeChart);
+            lineChart = dc.lineChart(compositeChart, this.get('uniqueChartGroupName'));
 
             lineChart
                 .group(g)

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -7,11 +7,7 @@ import d3Tip from 'd3-tip';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
 import { getTickFormat } from 'ember-data-visualizations/utils/d3-localization';
-
-import {
-    addComparisonLines,
-    addComparisonLineTicks
-} from 'ember-data-visualizations/utils/comparison-lines';
+import { addComparisonLines, addComparisonLineTicks } from 'ember-data-visualizations/utils/comparison-lines';
 
 /**
    @public
@@ -22,6 +18,7 @@ import {
 export default BaseChartComponent.extend({
     classNames: ['line-chart'],
 
+    elementToApplyTipSelector: 'circle.dot',
     showMaxMin: false,
     showComparisonLines: false,
     currentInterval: null,
@@ -106,8 +103,7 @@ export default BaseChartComponent.extend({
     createTooltip() {
         const formatter = this.get('xAxis.formatter') || (value => value);
         const titles = this.get('series').map(entry => entry.title);
-        let tip = d3Tip().attr('class', 'd3-tip')
-            .attr('id', this.get('elementId'))
+        let tip = d3Tip().attr('class', `d3-tip ${this.get('elementId')}`)
             .html(d => {
                 if (!isEmpty(titles)) {
                     let str = `<span class="tooltip-time">${moment(d.data.key).format(this.get('tooltipDateFormat'))}</span>`;
@@ -132,7 +128,7 @@ export default BaseChartComponent.extend({
             return;
         }
 
-        this.addClickHandlersAndTooltips(d3.select('.line-chart > svg > defs'), tip, 'circle.dot');
+        this.addClickHandlersAndTooltips(d3.select('.line-chart > svg > defs'), tip);
 
         let dots = chart.selectAll('.sub._0 circle.dot')._groups[0];
 

--- a/addon/components/pie-chart/component.js
+++ b/addon/components/pie-chart/component.js
@@ -150,8 +150,7 @@ export default BaseChartComponent.extend({
 
     createTooltip() {
         return d3Tip()
-            .attr('class', 'd3-tip pie-chart')
-            .attr('id', this.get('elementId'))
+            .attr('class', `d3-tip ${this.get('elementId')}`)
             .style('text-align', 'center')
             .html(d => {
                 return `<span class="pie-tip-key">${d.data.key}</span><br/><span class="pie-tip-value">${this.get('formatter')(d.data.value)}</span>`;

--- a/addon/components/pie-chart/component.js
+++ b/addon/components/pie-chart/component.js
@@ -23,7 +23,7 @@ export default BaseChartComponent.extend({
             return;
         }
 
-        let chart = dc.pieChart(`#${this.get('elementId')}`);
+        let chart = dc.pieChart(`#${this.get('elementId')}`, this.get('uniqueChartGroupName'));
         chart
             .radius(this.get('height') / 2)
             .ordinalColors(this.get('colors'))
@@ -209,7 +209,7 @@ export default BaseChartComponent.extend({
         const chartNotAvailableColor = this.get('chartNotAvailableColor');
         const chartNotAvailableTextColor = this.get('chartNotAvailableTextColor');
 
-        let pieChart = dc.pieChart(`#${this.get('elementId')}`);
+        let pieChart = dc.pieChart(`#${this.get('elementId')}`, this.get('uniqueChartGroupName'));
         this.set('chart', pieChart);
 
         const data = [{ key: '', value: 1 }];

--- a/addon/components/row-chart/component.js
+++ b/addon/components/row-chart/component.js
@@ -13,6 +13,7 @@ import d3 from 'd3';
 export default BaseChartComponent.extend({
     classNames: ['row-chart'],
 
+    elementToApplyTipSelector: 'g.row > rect',
     showMaxMin: false,
     showComparisonLine: false,
     currentInterval: null,
@@ -75,9 +76,8 @@ export default BaseChartComponent.extend({
     },
 
     createTooltip() {
-        return d3Tip().attr('class', 'd3-tip')
+        return d3Tip().attr('class', `d3-tip ${this.get('elementId')}`)
             .style('text-align', 'center')
-            .attr('id', this.get('elementId'))
             .html(d => `<span class="row-tip-key">${d.key}</span><br/><span class="row-tip-value">${d.value}</span>`)
             .direction('e');
     },
@@ -104,7 +104,7 @@ export default BaseChartComponent.extend({
             this.addLegend(chart, this.getLegendables(chart), legendG, legendDimension);
         }
 
-        this.addClickHandlersAndTooltips(chart.select('svg'), tip, 'g.row > rect');
+        this.addClickHandlersAndTooltips(chart.select('svg'), tip);
     },
 
     getLegendables(chart) {

--- a/addon/components/row-chart/component.js
+++ b/addon/components/row-chart/component.js
@@ -24,7 +24,7 @@ export default BaseChartComponent.extend({
     comparisonLine: null,
 
     buildChart() {
-        let rowChart = dc.rowChart(`#${this.get('elementId')}`);
+        let rowChart = dc.rowChart(`#${this.get('elementId')}`, this.get('uniqueChartGroupName'));
 
         let labels = [];
         this.get('group')[0].all().forEach(d => labels.push(d.key));
@@ -286,7 +286,7 @@ export default BaseChartComponent.extend({
         const chartNotAvailableColor = this.get('chartNotAvailableColor');
         const chartNotAvailableTextColor = this.get('chartNotAvailableTextColor');
 
-        let rowChart = dc.rowChart(`#${this.get('elementId')}`);
+        let rowChart = dc.rowChart(`#${this.get('elementId')}`, this.get('uniqueChartGroupName'));
         this.set('chart', rowChart);
 
         let data = [];

--- a/testem.js
+++ b/testem.js
@@ -19,12 +19,10 @@ module.exports = {
                 '--headless',
                 '--disable-gpu',
                 '--disable-dev-shm-usage',
-                '--disable-software-rasterizer',
                 '--mute-audio',
                 '--remote-debugging-port=0',
                 '--window-size=1440,900'
             ].filter(Boolean)
         }
-    },
-    reporter: 'dot'
+    }
 };

--- a/tests/integration/components/heat-map-test.js
+++ b/tests/integration/components/heat-map-test.js
@@ -35,8 +35,8 @@ const getTestParameters = function () {
         group,
         xAxis: {
             domain: [
-                moment('2016-11-01'),
-                moment('2016-11-05')
+                moment('2016-11-01', 'YYYY-MM-DD'),
+                moment('2016-11-05', 'YYYY-MM-DD')
             ],
             ticks: 3
         },
@@ -46,7 +46,7 @@ const getTestParameters = function () {
         },
 
         colorMap: d => d,
-        keyFormat: key => moment(key.toString()).format('MMM DD')
+        keyFormat: key => moment(key.toString(), 'YYYY-MM-DD').format('MMM DD')
     };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1288,11 +1288,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
-"@types/node@*":
-  version "12.0.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.2.tgz#3452a24edf9fea138b48fad4a0a028a683da1e40"
-  integrity sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==
-
 "@types/symlink-or-copy@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz#4151a81b4052c80bc2becbae09f3a9ec010a9c7a"
@@ -2340,7 +2335,7 @@ babel-plugin-ember-modules-api-polyfill@^2.6.0:
   dependencies:
     ember-rfc176-data "^0.3.6"
 
-babel-plugin-ember-modules-api-polyfill@^2.8.0, babel-plugin-ember-modules-api-polyfill@^2.9.0:
+babel-plugin-ember-modules-api-polyfill@^2.8.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz#8503e7b4192aeb336b00265e6235258ff6b754aa"
   integrity sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==
@@ -3915,18 +3910,6 @@ charm@^1.0.0:
   dependencies:
     inherits "^2.0.1"
 
-cheerio@^1.0.0-rc.2:
-  version "1.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
-  integrity sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==
-  dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.1"
-    entities "~1.1.1"
-    htmlparser2 "^3.9.1"
-    lodash "^4.15.0"
-    parse5 "^3.0.1"
-
 child-process-promise@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/child-process-promise/-/child-process-promise-2.2.1.tgz#4730a11ef610fad450b8f223c79d31d7bdad8074"
@@ -4531,7 +4514,7 @@ css-loader@^2.1.0:
     postcss-value-parser "^3.3.0"
     schema-utils "^1.0.0"
 
-css-select@^1.1.0, css-select@~1.2.0:
+css-select@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
@@ -4788,9 +4771,9 @@ d3-zoom@1:
     d3-transition "1"
 
 d3@^5.5.0, d3@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/d3/-/d3-5.7.0.tgz#f189d338bdde62acf02f308918e0ec34dd7568f9"
-  integrity sha512-8KEIfx+dFm8PlbJN9PI0suazrZ41QcaAufsKE9PRcqYPWLngHIyWJZX96n6IQKePGgeSu0l7rtlueSSNq8Zc3g==
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-5.11.0.tgz#d5ffc84f930eeb895d88699195d2d852778ab158"
+  integrity sha512-LXgMVUAEAzQh6WfEEOa8tJX4RA64ZJ6twC3CJ+Xzid+fXWLTZkkglagXav/eOoQgzQi5rzV0xC4Sfspd6hFDHA==
   dependencies:
     d3-array "1"
     d3-axis "1"
@@ -5053,7 +5036,7 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-serializer@0, dom-serializer@~0.1.1:
+dom-serializer@0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
   integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
@@ -5278,7 +5261,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0,
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.2, ember-cli-babel@^7.4.3:
+ember-cli-babel@^7.4.3:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.7.3.tgz#f94709f6727583d18685ca6773a995877b87b8a0"
   integrity sha512-/LWwyKIoSlZQ7k52P+6agC7AhcOBqPJ5C2u27qXHVVxKvCtg6ahNuRk/KmfZmV4zkuw4EjTZxfJE1PzpFyHkXg==
@@ -5439,14 +5422,6 @@ ember-cli-qunit@^4.3.2:
   dependencies:
     ember-cli-babel "^6.11.0"
     ember-qunit "^3.5.0"
-
-ember-cli-storybook@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-storybook/-/ember-cli-storybook-0.1.0.tgz#f652d037c2aa591e269dca873ead6eddd18f4e81"
-  integrity sha512-hcigBT1xGWX3n+WPHrOk95DJEyJ1iPhZ1Ha9ySX1vMkXp9oMf6dqrbnXUXrZcNBhZgSr/vzFD1Yjb5PF6uS1sg==
-  dependencies:
-    cheerio "^1.0.0-rc.2"
-    ember-cli-babel "^7.1.2"
 
 ember-cli-string-utils@^1.1.0:
   version "1.1.0"
@@ -7233,7 +7208,7 @@ html-webpack-plugin@^4.0.0-beta.2:
     tapable "^1.1.0"
     util.promisify "1.0.0"
 
-htmlparser2@^3.3.0, htmlparser2@^3.9.1:
+htmlparser2@^3.3.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
@@ -8663,7 +8638,7 @@ lodash.values@~2.3.0:
   dependencies:
     lodash.keys "~2.3.0"
 
-lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -9682,13 +9657,6 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
-
-parse5@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
-  integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
-  dependencies:
-    "@types/node" "*"
 
 parseqs@0.0.5:
   version "0.0.5"


### PR DESCRIPTION
When charts are created they get added to `dc.chartRegistry`. This was not getting cleaned up when chart components were being destroyed so we still had stray references to them. Also making sure to clean up click handlers and tooltips properly.