### PR TITLE
y-axis-ticks do not render fix - added extra false check

### DIFF
--- a/addon/utils/comparison-lines.js
+++ b/addon/utils/comparison-lines.js
@@ -4,7 +4,7 @@
    @param comparisonLines - Array of comparison lines passed to the chart component.
 */
 export function addComparisonLines(chart, comparisonLines) {
-    if (!chart || !comparisonLines) {
+    if (!chart || !comparisonLines || !comparisonLines.length) {
         return;
     }
 
@@ -55,7 +55,7 @@ export function addComparisonLines(chart, comparisonLines) {
    @param {array} comparisonLines - Array of comparison lines passed to the chart component.
 */
 export function addComparisonLineTicks(chart, comparisonLines) {
-    if (!chart || !comparisonLines) {
+    if (!chart || !comparisonLines || !comparisonLines.length) {
         return;
     }
 

--- a/addon/utils/comparison-lines.js
+++ b/addon/utils/comparison-lines.js
@@ -1,10 +1,11 @@
+import { isEmpty } from '@ember/utils';
 /**
    @desc Adds comparison lines to a line or column chart.
    @param chart - DC chart instance.
    @param comparisonLines - Array of comparison lines passed to the chart component.
 */
 export function addComparisonLines(chart, comparisonLines) {
-    if (!chart || !comparisonLines || !comparisonLines.length) {
+    if (!chart || isEmpty(comparisonLines)) {
         return;
     }
 
@@ -55,7 +56,7 @@ export function addComparisonLines(chart, comparisonLines) {
    @param {array} comparisonLines - Array of comparison lines passed to the chart component.
 */
 export function addComparisonLineTicks(chart, comparisonLines) {
-    if (!chart || !comparisonLines || !comparisonLines.length) {
+    if (!chart || isEmpty(comparisonLines)) {
         return;
     }
 


### PR DESCRIPTION
comparison lines list, even if empty, caused the ticks to not render.