### PR TITLE
[ENGAGEUI-3183] Localize xAxis when chart is not available

### DIFF
--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -643,6 +643,8 @@ export default BaseChartComponent.extend({
             .dimension(dimension)
             .transitionDuration(0);
 
+        columnChart.xAxis().tickFormat(getTickFormat(this.get('d3LocaleInfo')));
+
         if (this.get('width')) {
             this.get('chart').effectiveWidth(this.get('width'));
         }


### PR DESCRIPTION
Use d3LocaleInfo for xAxis of column chart when chart is not available