### PR TITLE
Restore hatching

### DIFF
--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -722,7 +722,7 @@ export default BaseChartComponent.extend({
             }
 
             // Set up any necessary hatching patterns
-            let svg = d3.select('.column-chart .dc-chart > .svg1 > defs');
+            let svg = d3.select('.column-chart .dc-chart > svg > defs');
 
             svg
                 .append('clippath')

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -722,7 +722,7 @@ export default BaseChartComponent.extend({
             }
 
             // Set up any necessary hatching patterns
-            let svg = d3.select('.column-chart > svg > defs');
+            let svg = d3.select('.column-chart .dc-chart > .svg1 > defs');
 
             svg
                 .append('clippath')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data-visualizations",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Ember addon to support visualizations with dc.js (d3 & crossfilter).",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
The column chart used to be rendered under the base component and was moved one level deeper to support expand/append behavior for legends.

These edits change our hatch-pattern append logic to look for the actual chart first, **then** edit the chart's defs.

Before:
```
<div class="column-chart">
    <!-- d3 column chart svg -->
</div>
```

After:
```
<div class="column-chart">
    <div id="column-chart-{elementId}>
        <!-- d3 column chart svg -->
    </div>
</div>
```

See the actual changes here:

Added template nesting:
https://github.com/purecloudlabs/ember-data-visualizations/pull/89/files#diff-c4e2f4092c1f57714a7297cf291506f9R1

Appending the dc chart one level deeper:
https://github.com/purecloudlabs/ember-data-visualizations/pull/89/files#diff-bdde94eede34f63c93eee46e787126caR58

Side: is there a good way to test this?