### PR TITLE
[ENGAGEUI-4090] add min-width to legend box

### DIFF
--- a/addon/styles/legend.less
+++ b/addon/styles/legend.less
@@ -16,6 +16,7 @@
             }
 
             .legend-box {
+                min-width: 13px;
                 border: 1px solid black;
                 display: inline-block;
                 margin-right: 3px;


### PR DESCRIPTION
Before:
<img width="275" alt="Screen Shot 2020-06-25 at 9 59 49 AM" src="https://user-images.githubusercontent.com/28989285/85734155-cbf98d80-b6ca-11ea-8f34-0e4afd38ba2d.png">

After:
<img width="275" alt="Screen Shot 2020-06-25 at 10 00 29 AM" src="https://user-images.githubusercontent.com/28989285/85734177-d156d800-b6ca-11ea-8a37-e618e73b07c7.png">
