### PR TITLE
Margin handling changes

### DIFF
--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -140,6 +140,7 @@ export default Component.extend({
         if (tip && !svg.empty()) {
             svg.call(tip);
         }
+
         // clicking actions
         this.get('chart').selectAll(this.elementToApplyTipSelector).on('click', d => {
             this.onClick(d);
@@ -170,6 +171,10 @@ export default Component.extend({
         this.get('chart').selectAll(this.elementToApplyTipSelector).on('click', null);
 
         this.get('chart').selectAll(this.elementToApplyTipSelector)
+            .on('mouseover.tip', null)
+            .on('mouseout.tip', null);
+
+        this.get('chart').selectAll('.comparison-line.tooltip-line')
             .on('mouseover.tip', null)
             .on('mouseout.tip', null);
     },

--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -7,7 +7,7 @@ import { computed } from '@ember/object';
 import { A } from '@ember/array';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
-import dc from 'dc';
+import dc, { legend } from 'dc';
 
 export default Component.extend({
     resizeDetector: service(),
@@ -52,6 +52,68 @@ export default Component.extend({
         const colors = this.get('colors');
         return colors[index] || colors[colors.length - 1];
     },
+
+    hasBottomLegend: computed('showLegend', 'shouldAppendLegendBelow', function () {
+        const showLegend = this.get('showLegend');
+        const shouldAppendLegendBelow = this.get('shouldAppendLegendBelow');
+
+        return showLegend && shouldAppendLegendBelow;
+    }),
+
+    hasRightLegend: computed('showLegend', 'legendOptions.position', function () {
+        const showLegend = this.get('showLegend');
+        const legendOptions = this.get('legendOptions');
+
+        return showLegend && legendOptions.position === 'right';
+    }),
+
+    chartMarginTop: computed('margins.top', function () {
+        const defaultTopMargin = ChartSizes.TOP_MARGIN;
+        const specifiedTopMargin = this.get('margins.top');
+
+        return specifiedTopMargin || defaultTopMargin;
+    }),
+
+    chartMarginBottom: computed('margins.bottom', function () {
+        const defaultBottomMargin = ChartSizes.BOTTOM_MARGIN;
+        const specifiedBottomMargin = this.get('margins.bottom');
+
+        return specifiedBottomMargin || defaultBottomMargin;
+    }),
+
+    chartMarginLeft: computed('margins.left', function () {
+        const defaultLeftMargin = ChartSizes.LEFT_MARGIN;
+        const specifiedLeftMargin = this.get('margins.left');
+
+        return specifiedLeftMargin || defaultLeftMargin;
+    }),
+
+    chartMarginRight: computed('margins.right', 'legendWidth', 'hasRightLegend', function () {
+        const hasRightLegend = this.get('hasRightLegend');
+        const legendWidth = this.get('legendWidth') || ChartSizes.LEGEND_WIDTH;
+
+        const defaultRightMargin = ChartSizes.RIGHT_MARGIN;
+        const defaultRightMarginWithLegend = legendWidth + ChartSizes.LEGEND_OFFSET_X;
+
+        const defaultMargin = hasRightLegend ? defaultRightMarginWithLegend : defaultRightMargin;
+        const specifiedRightMargin = this.get('margins.right');
+
+        return specifiedRightMargin || defaultMargin;
+    }),
+
+    chartMargins: computed('chartMarginLeft', 'chartMarginRight', 'chartMarginTop', 'chartMarginBottom', function () {
+        const chartMarginLeft = this.get('chartMarginLeft');
+        const chartMarginRight = this.get('chartMarginRight');
+        const chartMarginTop = this.get('chartMarginTop');
+        const chartMarginBottom = this.get('chartMarginBottom');
+
+        return {
+            left: chartMarginLeft,
+            right: chartMarginRight,
+            top: chartMarginTop,
+            bottom: chartMarginBottom
+        };
+    }),
 
     setupResize() {
         this.set('onResizeDebounced', () => {

--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -55,9 +55,9 @@ export default Component.extend({
 
     hasRightLegend: computed('showLegend', 'legendOptions.position', function () {
         const showLegend = this.get('showLegend');
-        const legendOptions = this.get('legendOptions');
+        const isPositionRight = this.get('legendOptions.position') === 'right';
 
-        return showLegend && legendOptions.position === 'right';
+        return showLegend && isPositionRight;
     }),
 
     chartMarginTop: computed('margins.top', function () {
@@ -95,17 +95,12 @@ export default Component.extend({
     }),
 
     chartMargins: computed('chartMarginLeft', 'chartMarginRight', 'chartMarginTop', 'chartMarginBottom', function () {
-        const chartMarginLeft = this.get('chartMarginLeft');
-        const chartMarginRight = this.get('chartMarginRight');
-        const chartMarginTop = this.get('chartMarginTop');
-        const chartMarginBottom = this.get('chartMarginBottom');
+        const left = this.get('chartMarginLeft');
+        const right = this.get('chartMarginRight');
+        const top = this.get('chartMarginTop');
+        const bottom = this.get('chartMarginBottom');
 
-        return {
-            left: chartMarginLeft,
-            right: chartMarginRight,
-            top: chartMarginTop,
-            bottom: chartMarginBottom
-        };
+        return { top, right, bottom, left };
     }),
 
     setupResize() {

--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -7,7 +7,7 @@ import { computed } from '@ember/object';
 import { A } from '@ember/array';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
-import dc, { legend } from 'dc';
+import dc from 'dc';
 
 export default Component.extend({
     resizeDetector: service(),
@@ -52,13 +52,6 @@ export default Component.extend({
         const colors = this.get('colors');
         return colors[index] || colors[colors.length - 1];
     },
-
-    hasBottomLegend: computed('showLegend', 'shouldAppendLegendBelow', function () {
-        const showLegend = this.get('showLegend');
-        const shouldAppendLegendBelow = this.get('shouldAppendLegendBelow');
-
-        return showLegend && shouldAppendLegendBelow;
-    }),
 
     hasRightLegend: computed('showLegend', 'legendOptions.position', function () {
         const showLegend = this.get('showLegend');

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -38,9 +38,12 @@ export default BaseChartComponent.extend({
     }),
 
     legendOptions: null,
-
     showLegend: bool('legendOptions.showLegend'),
     shouldAppendLegendBelow: equal('legendOptions.position', 'bottom'),
+
+    comparisonLineOptions: null,
+    showComparisonLineTooltips: bool('comparisonLineOptions.showTooltips'),
+    showComparisonLineYAxisLabels: bool('comparisonLineOptions.showYAxisLabels'),
 
     legendHeight: computed('legendOptions.height', function () {
         return this.get('legendOptions.height') || ChartSizes.LEGEND_HEIGHT;
@@ -160,13 +163,14 @@ export default BaseChartComponent.extend({
             columnCharts.push(columnChart);
         }
 
-        addComparisonLineTicks(compositeChart, this.get('comparisonLines'));
-
         const domainTicks = this.get('yAxis.domain') || [];
+        const comparisonLines = this.get('comparisonLines') || [];
 
+        addComparisonLineTicks(compositeChart, comparisonLines);
+
+        // allow hiding comparison line labels on the y-axis
         let otherDomainTicks = [];
-        const comparisonLines = this.get('comparisonLines');
-        const showComparisonLineYAxisLabels = this.get('comparisonLineOptions.showYAxisLabel');
+        const showComparisonLineYAxisLabels = this.get('comparisonLineOptions.showYAxisLabels');
 
         if (showComparisonLineYAxisLabels) {
             otherDomainTicks = comparisonLines.map(d => d.value);
@@ -353,11 +357,19 @@ export default BaseChartComponent.extend({
             this.addDataValues(bars, chart);
         }
 
-        if (!isEmpty(this.get('showComparisonLines')) && this.get('comparisonLines') && !isEmpty(this.get('data'))) {
+        const data = this.get('data');
+        const comparisonLines = this.get('comparisonLines') || [];
+        const showComparisonLines = this.get('showComparisonLines');
+        const showComparisonLineTooltips = this.get('showComparisonLineTooltips');
+
+        if (showComparisonLines && comparisonLines.length && !isEmpty(data)) {
             const comparisonLineFormatter = this.get('xAxis.formatter');
 
-            addComparisonLines(chart, this.get('comparisonLines'));
-            addComparisonLineTooltips(chart, comparisonLineFormatter);
+            addComparisonLines(chart, comparisonLines);
+
+            if (showComparisonLineTooltips) {
+                addComparisonLineTooltips(chart, comparisonLineFormatter);
+            }
         }
 
         if (this.get('showCurrentIndicator') && this.get('currentInterval')) {

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -7,7 +7,7 @@ import d3Tip from 'd3-tip';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
 import { getTickFormat } from 'ember-data-visualizations/utils/d3-localization';
-import { addComparisonLines, addComparisonLineTicks } from 'ember-data-visualizations/utils/comparison-lines';
+import { addComparisonLines, addComparisonLineTicks, addComparisonLineTooltips } from 'ember-data-visualizations/utils/comparison-lines';
 import { padDomain, addDomainTicks } from 'ember-data-visualizations/utils/domain-tweaks';
 import { computed } from '@ember/object';
 import { equal, bool } from '@ember/object/computed';
@@ -354,8 +354,10 @@ export default BaseChartComponent.extend({
         }
 
         if (!isEmpty(this.get('showComparisonLines')) && this.get('comparisonLines') && !isEmpty(this.get('data'))) {
+            const comparisonLineFormatter = this.get('xAxis.formatter');
+
             addComparisonLines(chart, this.get('comparisonLines'));
-            // todo: comparison line should be hoverable to view value
+            addComparisonLineTooltips(chart, comparisonLineFormatter);
         }
 
         if (this.get('showCurrentIndicator') && this.get('currentInterval')) {

--- a/addon/components/column-chart/component.js
+++ b/addon/components/column-chart/component.js
@@ -42,8 +42,14 @@ export default BaseChartComponent.extend({
     shouldAppendLegendBelow: equal('legendOptions.position', 'bottom'),
 
     comparisonLineOptions: null,
-    showComparisonLineTooltips: bool('comparisonLineOptions.showTooltips'),
-    showComparisonLineYAxisLabels: bool('comparisonLineOptions.showYAxisLabels'),
+
+    _comparisonLineOptions: computed('comparisonLineOptions.${showYAxisLabels,showTooltips}', function () {
+        const defaults = { showYAxisLabels: true, showTooltips: false };
+        return this.get('comparisonLineOptions') || defaults;
+    }),
+
+    showComparisonLineTooltips: bool('_comparisonLineOptions.showTooltips'),
+    showComparisonLineYAxisLabels: bool('_comparisonLineOptions.showYAxisLabels'),
 
     legendHeight: computed('legendOptions.height', function () {
         return this.get('legendOptions.height') || ChartSizes.LEGEND_HEIGHT;
@@ -170,7 +176,7 @@ export default BaseChartComponent.extend({
 
         // allow hiding comparison line labels on the y-axis
         let otherDomainTicks = [];
-        const showComparisonLineYAxisLabels = this.get('comparisonLineOptions.showYAxisLabels');
+        const showComparisonLineYAxisLabels = this.get('showComparisonLineYAxisLabels');
 
         if (showComparisonLineYAxisLabels) {
             otherDomainTicks = comparisonLines.map(d => d.value);

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -71,16 +71,13 @@ export default BaseChartComponent.extend({
         // let d3 handle scaling if not otherwise specified
         const useElasticY = !this.get('yAxis.domain');
 
+        const { top, right, bottom, left } = this.get('chartMargins');
+
         compositeChart
             .renderTitle(false)
             .brushOn(false)
             .height(height)
-            .margins({
-                top: 10,
-                right: rightMargin,
-                bottom: bottomMargin,
-                left: 100
-            })
+            .margins({ top, right, bottom, left })
             .x(d3.scaleTime().domain(this.get('xAxis').domain))
             .xUnits(() => {
                 if (this.get('group.length')) {
@@ -135,7 +132,18 @@ export default BaseChartComponent.extend({
         });
 
         addComparisonLineTicks(compositeChart, this.get('comparisonLines'));
-        addDomainTicks(compositeChart, this.get('yAxis').domain, this.get('comparisonLines') ? this.get('comparisonLines').map(d => d.value) : undefined);
+
+        const domainTicks = this.get('yAxis.domain') || [];
+
+        let otherDomainTicks = [];
+        const comparisonLines = this.get('comparisonLines');
+        const showComparisonLineYAxisLabels = this.get('comparisonLineOptions.showYAxisLabel');
+
+        if (showComparisonLineYAxisLabels) {
+            otherDomainTicks = comparisonLines.map(d => d.value);
+        }
+
+        addDomainTicks(compositeChart, domainTicks, otherDomainTicks);
 
         compositeChart
             .on('renderlet', chart => this.onRenderlet(chart, tip))
@@ -193,6 +201,7 @@ export default BaseChartComponent.extend({
 
         if (this.get('showComparisonLines') && this.get('comparisonLines') && !isEmpty(this.get('data'))) {
             addComparisonLines(chart, this.get('comparisonLines'));
+            // todo: add tooltip for comparison line
         }
 
         if (this.get('showCurrentIndicator') && this.get('currentInterval')) {

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -10,7 +10,7 @@ import { getTickFormat } from 'ember-data-visualizations/utils/d3-localization';
 import { addComparisonLines, addComparisonLineTicks, addComparisonLineTooltips } from 'ember-data-visualizations/utils/comparison-lines';
 import { addDomainTicks } from 'ember-data-visualizations/utils/domain-tweaks';
 import { computed } from '@ember/object';
-import { equal, bool, reads } from '@ember/object/computed';
+import { equal, bool } from '@ember/object/computed';
 
 import layout from './template';
 
@@ -60,17 +60,6 @@ export default BaseChartComponent.extend({
         let compositeChart = dc.compositeChart(chartId, this.get('uniqueChartGroupName'));
 
         const height = this.get('height');
-        const showLegend = this.get('showLegend');
-        const shouldAppendLegendBelow = this.get('shouldAppendLegendBelow');
-
-        // if the legend renders on the right, give the right margin enough room to render the legend
-        const legendWidth = this.get('legendWidth') || ChartSizes.LEGEND_WIDTH;
-        const legendInsetX = legendWidth + ChartSizes.LEGEND_OFFSET_X;
-
-        const rightMargin = showLegend && !shouldAppendLegendBelow ? legendInsetX : ChartSizes.RIGHT_MARGIN;
-
-        // if the legend renders below the chart, we want the chart as close to the bottom as possible
-        const bottomMargin = showLegend && !shouldAppendLegendBelow ? ChartSizes.BOTTOM_MARGIN : 20;
 
         // let d3 handle scaling if not otherwise specified
         const useElasticY = !this.get('yAxis.domain');

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -7,7 +7,7 @@ import d3Tip from 'd3-tip';
 import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
 import { getTickFormat } from 'ember-data-visualizations/utils/d3-localization';
-import { addComparisonLines, addComparisonLineTicks } from 'ember-data-visualizations/utils/comparison-lines';
+import { addComparisonLines, addComparisonLineTicks, addComparisonLineTooltips } from 'ember-data-visualizations/utils/comparison-lines';
 import { addDomainTicks } from 'ember-data-visualizations/utils/domain-tweaks';
 import { computed } from '@ember/object';
 import { equal, bool } from '@ember/object/computed';
@@ -199,9 +199,11 @@ export default BaseChartComponent.extend({
             this.addMaxMinLabels(dots);
         }
 
-        if (this.get('showComparisonLines') && this.get('comparisonLines') && !isEmpty(this.get('data'))) {
+        if (this.get('showComparisonLines') && this.get('comparisonLines.length') && !isEmpty(this.get('data'))) {
+            const comparisonLineFormatter = this.get('xAxis.formatter');
+
             addComparisonLines(chart, this.get('comparisonLines'));
-            // todo: add tooltip for comparison line
+            addComparisonLineTooltips(chart, comparisonLineFormatter);
         }
 
         if (this.get('showCurrentIndicator') && this.get('currentInterval')) {
@@ -423,7 +425,6 @@ export default BaseChartComponent.extend({
         this.set('chart', compositeChart);
 
         compositeChart.on('postRender', () => {
-
             // This is outside the Ember run loop so check if component is destroyed
             if (this.get('isDestroyed') || this.get('isDestroying')) {
                 return;

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -41,8 +41,14 @@ export default BaseChartComponent.extend({
     shouldAppendLegendBelow: equal('legendOptions.position', 'bottom'),
 
     comparisonLineOptions: null,
-    showComparisonLineTooltips: bool('comparisonLineOptions.showTooltips'),
-    showComparisonLineYAxisLabels: bool('comparisonLineOptions.showYAxisLabels'),
+
+    _comparisonLineOptions: computed('comparisonLineOptions.${showYAxisLabels,showTooltips}', function () {
+        const defaults = { showYAxisLabels: true, showTooltips: false };
+        return this.get('comparisonLineOptions') || defaults;
+    }),
+
+    showComparisonLineTooltips: bool('_comparisonLineOptions.showTooltips'),
+    showComparisonLineYAxisLabels: bool('_comparisonLineOptions.showYAxisLabels'),
 
     legendHeight: computed('legendOptions.height', function () {
         return this.get('legendOptions.height') || ChartSizes.LEGEND_HEIGHT;

--- a/addon/utils/chart-sizes.js
+++ b/addon/utils/chart-sizes.js
@@ -1,21 +1,28 @@
 // All sizes are in pixels.
 const chart = {
+    marginTop: 10,
     marginRight: 100,
-    marginBottom: 50
+    marginBottom: 25,
+    marginLeft: 100
 };
 
 const legend = {
     width: 250,
     height: 50,
     offsetX: 35,
+    offsetY: 20,
     fontSize: 13
 };
 
 export default {
+    TOP_MARGIN: chart.marginTop,
     RIGHT_MARGIN: chart.marginRight,
     BOTTOM_MARGIN: chart.marginBottom,
+    LEFT_MARGIN: chart.marginLeft,
+
     LEGEND_WIDTH: legend.width,
     LEGEND_HEIGHT: legend.height,
     LEGEND_OFFSET_X: legend.offsetX,
+    LEGEND_OFFSET_Y: legend.offsetY,
     LEGEND_FONTSIZE: legend.fontSize
 };

--- a/addon/utils/comparison-lines.js
+++ b/addon/utils/comparison-lines.js
@@ -97,7 +97,7 @@ export function addComparisonLineTooltips(chart, formatter) {
     if (chart) {
         const chartDefs = chart.select('svg > defs');
 
-        const tip = d3Tip().attr('class', `d3-tip comparison-tooltip`).html(d => {
+        const tip = d3Tip().attr('class', 'd3-tip comparison-tooltip').html(d => {
             return formatter ? formatter(d.value) : d.value;
         });
 

--- a/addon/utils/comparison-lines.js
+++ b/addon/utils/comparison-lines.js
@@ -108,11 +108,17 @@ export function addComparisonLineTooltips(chart, formatter) {
         chart.selectAll('.comparison-line.tooltip-line')
             .on('mouseover.tip', function (d) {
                 const svgLine = chart.select(`.comparison-line-${d.lineIndex}`).node();
-                tip.show(d, svgLine);
+
+                if (svgLine) {
+                    tip.show(d, svgLine);
+                }
             })
             .on('mouseout.tip', function (d) {
                 const svgLine = chart.select(`.comparison-line-${d.lineIndex}`).node();
-                tip.hide(d, svgLine);
+
+                if (svgLine) {
+                    tip.hide(d, svgLine);
+                }
             });
     }
 }


### PR DESCRIPTION
Changes to allow more flexibility with the amount of margin in column / line charts.

1. `margins` parameter: specify something like { top: 20, left: 30 } for more control of margins
2. `comarisonLineOptions` parameter: options for more control over comparison lines
