### PR TITLE
[ENGAGEUI-4122] correctly cleanup chart tooltips

### DIFF
--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -295,7 +295,7 @@ export default Component.extend({
                 .on('renderlet', null)
                 .on('postRender', null);
         }
-        let tooltips = document.querySelectorAll(`.d3-tip.${this.get('elementId')}`);
+        let tooltips = document.querySelectorAll(`.d3-tip.${this.get('chartId')}`);
         if (tooltips && tooltips.length) {
             tooltips.forEach(tooltip => {
                 tooltip.remove();


### PR DESCRIPTION
To verify: hover over bar, so then click the bar and don't move your mouse. On an unfixed branch, a tooltip for the old bar will appear, and remain in place after the new chart loads. On the fixed branch, it will briefly appear, then get correctly removed.