### PR TITLE
remove future date values from line charts

### DIFF
--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -9,7 +9,6 @@ import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
 import dc from 'dc';
 import { getTickFormat } from 'ember-data-visualizations/utils/d3-localization';
-import moment from 'moment';
 
 export default Component.extend({
     resizeDetector: service(),
@@ -421,7 +420,6 @@ export default Component.extend({
             });
         }
 
-        this.set('now', moment());
         this.set('data', data);
 
         scheduleOnce('afterRender', this, this.setupResize);

--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -9,6 +9,7 @@ import d3 from 'd3';
 import ChartSizes from 'ember-data-visualizations/utils/chart-sizes';
 import dc from 'dc';
 import { getTickFormat } from 'ember-data-visualizations/utils/d3-localization';
+import moment from 'moment';
 
 export default Component.extend({
     resizeDetector: service(),
@@ -396,7 +397,7 @@ export default Component.extend({
 
     didReceiveAttrs() {
         this._super(...arguments);
-        let data = {};
+        const data = {};
         if (Array.isArray(this.get('group'))) {
             A(this.get('group')).forEach(g => {
                 A(g.all()).forEach(datum => {
@@ -419,6 +420,8 @@ export default Component.extend({
                 }
             });
         }
+
+        this.set('now', moment());
         this.set('data', data);
 
         scheduleOnce('afterRender', this, this.setupResize);

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -78,6 +78,7 @@ export default BaseChartComponent.extend({
         const compositeChart = this._getBaseChart(ChartTypes.COMPOSITE);
 
         const height = this.get('height');
+        const datumExcluder = this.get('datumExcluder');
 
         // let d3 handle scaling if not otherwise specified
         const useElasticY = !this.get('yAxis.domain');
@@ -118,17 +119,11 @@ export default BaseChartComponent.extend({
                 .group(g)
                 .colors(this.get('colors')[index])
                 .renderTitle(false)
-                .elasticY(true)
-                .defined(d => {
-                    const now = this.get('now');
-                    const isXDate = moment.isDate(d.x);
+                .elasticY(true);
 
-                    if (isXDate) {
-                        return moment(d.x).isSameOrBefore(now);
-                    }
-
-                    return true;
-                });
+            if (datumExcluder && typeof datumExcluder === 'function') {
+                lineChart.defined(d => datumExcluder(d));
+            }
 
             lineCharts.push(lineChart);
         });

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -94,7 +94,7 @@ export default BaseChartComponent.extend({
                 return 0;
             })
             .elasticY(useElasticY)
-            .yAxisPadding('20%')
+            .yAxisPadding('20%');
 
         if (this.get('yAxis') && this.get('yAxis').domain) {
             compositeChart.y(d3.scaleLinear().domain(this.get('yAxis').domain));
@@ -118,7 +118,17 @@ export default BaseChartComponent.extend({
                 .group(g)
                 .colors(this.get('colors')[index])
                 .renderTitle(false)
-                .elasticY(true);
+                .elasticY(true)
+                .defined(d => {
+                    const now = this.get('now');
+                    const isXDate = moment.isDate(d.x);
+
+                    if (isXDate) {
+                        return moment(d.x).isSameOrBefore(now);
+                    }
+
+                    return true;
+                });
 
             lineCharts.push(lineChart);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data-visualizations",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "Ember addon to support visualizations with dc.js (d3 & crossfilter).",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Hide future interval data in line charts. Still support updates, by updating the now reference prior to redrawing the chart