### PR TITLE
handled htmlSafe strings in title of tooltips

### DIFF
--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -160,10 +160,9 @@ export default BaseChartComponent.extend({
                 if (!isEmpty(titles)) {
                     let str = `<span class="tooltip-time">${moment(d.data.key).format(this.get('tooltipDateFormat'))}</span>`;
                     titles.forEach((title, i) => {
-                        // if title is an ember htmlSafe object instead of string
-                        if (typeof title === 'object' && title.string) {
-                            title = title.string;
-                        }
+                        // if title is an ember htmlSafe object instead of string,  use the String constructor to stringify the htmlSafe object. 
+                        title = String(title);
+                        
                         const value = this.get('data')[d.data.key][i];
                         const formattedValue = formatter(value);
                         const secondaryClass = d.y === value ? 'primary-stat' : '';

--- a/addon/components/line-chart/component.js
+++ b/addon/components/line-chart/component.js
@@ -160,6 +160,10 @@ export default BaseChartComponent.extend({
                 if (!isEmpty(titles)) {
                     let str = `<span class="tooltip-time">${moment(d.data.key).format(this.get('tooltipDateFormat'))}</span>`;
                     titles.forEach((title, i) => {
+                        // if title is an ember htmlSafe object instead of string
+                        if (typeof title === 'object' && title.string) {
+                            title = title.string;
+                        }
                         const value = this.get('data')[d.data.key][i];
                         const formattedValue = formatter(value);
                         const secondaryClass = d.y === value ? 'primary-stat' : '';

--- a/tests/integration/components/line-chart-test.js
+++ b/tests/integration/components/line-chart-test.js
@@ -1,7 +1,8 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { htmlSafe } from '@ember/template';
+import { render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
 import crossfilter from 'crossfilter';
@@ -40,7 +41,7 @@ const getTestParameters = function () {
 
         series: [
             {
-                title: 'Total Fruit Eaten',
+                title: htmlSafe('Total Fruit Eaten'),
                 hatch: 'pos'
             },
             {
@@ -136,5 +137,12 @@ module('Integration | Component | line chart', function (hooks) {
         assert.dom('.max-value-indicator').exists();
         assert.dom('.min-value-text').exists();
         assert.dom('.min-value-indicator').exists();
+    });
+
+    test('it renders tooltip if the title is an ember htmlSafe object', async function (assert) {
+        await render(hbs`{{line-chart dimension=params.dimensions group=params.groups series=params.series xAxis=params.xAxis yAxis=params.yAxis instantRun=true}}`);
+        await triggerEvent(document.querySelector('circle.dot'), 'mouseover');
+        const tooltip = document.querySelector('.d3-tip');
+        assert.ok(tooltip, 'Expect tooltip to show');
     });
 });


### PR DESCRIPTION
ticket:
https://inindca.atlassian.net/browse/ENGAGEUI-4423

in some cases tooltips on charts wouldn't show because of improper handling of htmlSafe strings in createTooltip() function.