### PR TITLE
Release/v3.13.1

### DIFF
--- a/addon/components/base-chart-component.js
+++ b/addon/components/base-chart-component.js
@@ -384,6 +384,8 @@ export default Component.extend({
                 tooltip.remove();
             });
         }
+
+        dc.chartRegistry.clear(this.get('uniqueChartGroupName'));
     },
 
     willDestroyElement() {
@@ -391,7 +393,6 @@ export default Component.extend({
         this.cleanupCurrentChart();
         this.tearDownResize();
         this.cancelTimers();
-        dc.chartRegistry.clear(this.get('uniqueChartGroupName'));
     },
 
     didReceiveAttrs() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-data-visualizations",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "Ember addon to support visualizations with dc.js (d3 & crossfilter).",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Fixes a memory leak caused by the DC chart registry growing unbounded. A new chart registry entry is added on every `didReceiveAttrs` and every time the window resize handler fired, and the old entries were never being cleared. Each of these entries had closures around the old detached SVG elements, so the memory used by those elements could never be released and garbage collected.